### PR TITLE
テストを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 # Omit committing pubspec.lock for library packages; see
 # https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock
+
+test/.env

--- a/lib/src/misskey_dart_base.dart
+++ b/lib/src/misskey_dart_base.dart
@@ -41,8 +41,18 @@ class Misskey {
   late final MisskeyMute mute;
   late final MisskeyRenoteMute renoteMute;
 
-  Misskey({required this.token, required this.host}) {
-    apiService = ApiService(token: token, host: host);
+  Misskey({
+    required this.token,
+    required this.host,
+    String? apiUrl,
+    String? streamingUrl,
+  }) {
+    apiService = ApiService(
+      token: token,
+      host: host,
+      apiUrl: apiUrl,
+      streamingUrl: streamingUrl,
+    );
 
     notes = MisskeyNotes(apiService: apiService);
     channels = MisskeyChannels(apiService: apiService);

--- a/lib/src/services/api_service.dart
+++ b/lib/src/services/api_service.dart
@@ -11,11 +11,18 @@ class ApiService {
   final Dio dio = Dio();
   final String token;
   final String host;
+  final String? apiUrl;
+  final String? streamingUrl;
 
-  ApiService({required this.token, required this.host}) {
+  ApiService({
+    required this.token,
+    required this.host,
+    this.apiUrl,
+    this.streamingUrl,
+  }) {
     dio.options = BaseOptions(
       method: "post",
-      baseUrl: "${Uri.https(host)}/api/",
+      baseUrl: apiUrl ?? "${Uri.https(host)}/api/",
       contentType: "application/json",
     );
     dio.interceptors.add(LogInterceptor(requestBody: true));
@@ -61,7 +68,7 @@ class ApiService {
   }) {
     id ??= "${channel.name}${DateTime.now().toIso8601String()}";
     return SocketController(
-        url: "wss://$host/streaming?i=$token",
+        url: "${streamingUrl ?? "wss://$host/streaming"}?i=$token",
         id: id,
         channel: channel,
         onEventReceived: onEventReceived,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,10 +8,12 @@ environment:
 
 dev_dependencies:
   build_runner: ^2.3.3
+  dotenv: ^4.1.0
   freezed: ^2.3.2
   json_serializable: ^6.6.1
   lints: ^2.0.0
   test: ^1.16.0
+  uuid: ^3.0.7
 dependencies:
   collection: ^1.16.0
   dio: ^5.1.1

--- a/test/.env.example
+++ b/test/.env.example
@@ -1,0 +1,5 @@
+TEST_HOST=localhost:3000
+TEST_API_URL=http://localhost:3000/api/
+TEST_STREAMING_URL=ws://localhost:3000/streaming/
+TEST_ADMIN_TOKEN=xxxxxxxx
+TEST_USER_TOKEN=xxxxxxxx

--- a/test/misskey_dart_test.dart
+++ b/test/misskey_dart_test.dart
@@ -1,12 +1,596 @@
-import 'package:misskey_dart/misskey_dart.dart';
-import 'package:test/test.dart';
+import 'dart:async';
+import 'dart:io';
 
-void main() {
-  group('A group of tests', () {
-    setUp(() {
-      // Additional setup goes here.
+import 'package:dotenv/dotenv.dart';
+import 'package:misskey_dart/misskey_dart.dart';
+import 'package:misskey_dart/src/enums/antenna_source.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+Misskey getTestClient(String token) {
+  final env = DotEnv(includePlatformEnvironment: true)..load(["test/.env"]);
+  return Misskey(
+    token: token,
+    host: env["TEST_HOST"]!,
+    apiUrl: env["TEST_API_URL"],
+    streamingUrl: env["TEST_STREAMING_URL"],
+  );
+}
+
+Future<User> createUser(Misskey adminClient) async {
+  final response = await adminClient.apiService.post<Map<String, dynamic>>(
+    "admin/accounts/create",
+    {
+      "username": Uuid().v4().replaceAll("-", "").substring(0, 20),
+      "password": "test",
+    },
+  );
+  return User.fromJson(response);
+}
+
+Future<Note> createNote(Misskey client) async {
+  final response = await client.apiService
+      .post<Map<String, dynamic>>("notes/create", {"text": "test"});
+  return Note.fromJson(response["createdNote"]);
+}
+
+void main() async {
+  final env = DotEnv(includePlatformEnvironment: true)..load(["test/.env"]);
+  final adminClient = getTestClient(env["TEST_ADMIN_TOKEN"]!);
+  final admin = await adminClient.i.i();
+  final userClient = getTestClient(env["TEST_USER_TOKEN"]!);
+  final user = await userClient.i.i();
+
+  group("API tests", () {
+    group("antennas", () {
+      test("create", () async {
+        await userClient.antennas.create(AntennasCreateRequest(
+          name: "test",
+          src: AntennaSource.all,
+          keywords: [
+            ["keyword"]
+          ],
+          excludeKeywords: [[]],
+          users: [],
+          caseSensitive: false,
+          withReplies: false,
+          withFile: false,
+          notify: false,
+        ));
+      });
+
+      test("delete", () async {
+        final antenna = await userClient.antennas.create(AntennasCreateRequest(
+          name: "test",
+          src: AntennaSource.all,
+          keywords: [
+            ["keyword"]
+          ],
+          excludeKeywords: [[]],
+          users: [],
+          caseSensitive: false,
+          withReplies: false,
+          withFile: false,
+          notify: false,
+        ));
+        await userClient.antennas
+            .delete(AntennasDeleteRequest(antennaId: antenna.id));
+      });
+
+      test("list", () async {
+        await userClient.antennas.list();
+      });
+
+      test("notes", () async {
+        final antenna = await userClient.antennas.create(AntennasCreateRequest(
+          name: "test",
+          src: AntennaSource.all,
+          keywords: [
+            ["keyword"]
+          ],
+          excludeKeywords: [[]],
+          users: [],
+          caseSensitive: false,
+          withReplies: false,
+          withFile: false,
+          notify: false,
+        ));
+        await userClient.antennas
+            .notes(AntennasNotesRequest(antennaId: antenna.id));
+      });
+
+      test("show", () async {
+        final antenna = await userClient.antennas.create(AntennasCreateRequest(
+          name: "test",
+          src: AntennaSource.all,
+          keywords: [
+            ["keyword"]
+          ],
+          excludeKeywords: [[]],
+          users: [],
+          caseSensitive: false,
+          withReplies: false,
+          withFile: false,
+          notify: false,
+        ));
+        await userClient.antennas
+            .show(AntennasShowRequest(antennaId: antenna.id));
+      });
+
+      test("update", () async {
+        final antenna = await userClient.antennas.create(AntennasCreateRequest(
+          name: "test",
+          src: AntennaSource.all,
+          keywords: [
+            ["keyword"]
+          ],
+          excludeKeywords: [[]],
+          users: [],
+          caseSensitive: false,
+          withReplies: false,
+          withFile: false,
+          notify: false,
+        ));
+        await userClient.antennas.update(AntennasUpdateRequest(
+          antennaId: antenna.id,
+          name: "updated",
+          src: AntennaSource.users,
+          keywords: [[]],
+          excludeKeywords: [
+            ["keyword"]
+          ],
+          users: ["@admin"],
+          caseSensitive: true,
+          withReplies: true,
+          withFile: true,
+          notify: true,
+        ));
+      });
     });
 
-    test('First Test', () {});
+    group("blocking", () {
+      test("create", () async {
+        final newUser = await createUser(adminClient);
+        await userClient.blocking
+            .create(BlockCreateRequest(userId: newUser.id));
+      });
+
+      test("delete", () async {
+        final newUser = await createUser(adminClient);
+        await userClient.blocking
+            .create(BlockCreateRequest(userId: newUser.id));
+        await userClient.blocking
+            .delete(BlockDeleteRequest(userId: newUser.id));
+      });
+    });
+
+    group("channels", () {});
+
+    group("clips", () {});
+
+    group("drive", () {
+      group("files", () {
+        test("create", () async {
+          final dir = Directory.systemTemp;
+          final name = Uuid().v4();
+          final path = "${dir.path}/$name.txt";
+          final file = await File(path).create();
+          await file.writeAsString("test");
+          await userClient.drive.files.create(DriveFilesCreateRequest(), file);
+        });
+
+        test("files", () async {
+          await userClient.drive.files.files(DriveFilesRequest());
+        });
+      });
+
+      group("folders", () {
+        test("folders", () async {
+          await userClient.drive.folders.folders(DriveFoldersRequest());
+        });
+      });
+    });
+
+    group("following", () {
+      test("create", () async {
+        final newUser = await createUser(adminClient);
+        await userClient.following
+            .create(FollowingCreateRequest(userId: newUser.id));
+      });
+
+      test("delete", () async {
+        final newUser = await createUser(adminClient);
+        await userClient.following
+            .create(FollowingCreateRequest(userId: newUser.id));
+        await userClient.following
+            .delete(FollowingDeleteRequest(userId: newUser.id));
+      });
+    });
+
+    group("i", () {
+      test("i", () async {
+        await userClient.i.i();
+      });
+
+      test("notifications", () async {
+        await userClient.i.notifications(INotificationsRequest());
+      });
+
+      test("favorites", () async {
+        await userClient.i.favorites(IFavoritesRequest());
+      });
+
+      test("update", () async {
+        await userClient.i.update(IUpdateRequest());
+      });
+    });
+
+    group("mute", () {
+      test("create", () async {
+        final newUser = await createUser(adminClient);
+        await userClient.mute.create(MuteCreateRequest(userId: newUser.id));
+      });
+
+      test("delete", () async {
+        final newUser = await createUser(adminClient);
+        await userClient.mute.create(MuteCreateRequest(userId: newUser.id));
+        await userClient.mute.delete(MuteDeleteRequest(userId: newUser.id));
+      });
+    });
+
+    group("notes", () {
+      test("create", () async {
+        await userClient.notes.create(NotesCreateRequest(text: "test"));
+      });
+
+      test("delete", () async {
+        final note = await createNote(userClient);
+        await userClient.notes.delete(NotesDeleteRequest(noteId: note.id));
+      });
+
+      test("notes", () async {
+        await userClient.notes.notes(NotesRequest());
+      });
+
+      test("show", () async {
+        final note = await createNote(userClient);
+        await userClient.notes.show(NotesShowRequest(noteId: note.id));
+      });
+
+      test("homeTimeline", () async {
+        await userClient.notes.homeTimeline(NotesTimelineRequest());
+      });
+
+      test("localTimeline", () async {
+        await userClient.notes.homeTimeline(NotesTimelineRequest());
+      });
+
+      test("hybridTimeline", () async {
+        await userClient.notes.homeTimeline(NotesTimelineRequest());
+      });
+
+      test("userListTimeline", () async {
+        await userClient.notes.homeTimeline(NotesTimelineRequest());
+      });
+
+      test("state", () async {
+        final note = await createNote(userClient);
+        await userClient.notes.state(NotesStateRequest(noteId: note.id));
+      });
+
+      test("search", () async {
+        await userClient.notes.search(NotesSearchRequest(query: "query"));
+      });
+
+      test("searchByTag", () async {
+        await userClient.notes.searchByTag(NotesSearchByTagRequest(tag: "tag"));
+      });
+
+      group("reactions", () {
+        test("create", () async {
+          final note = await createNote(userClient);
+          await userClient.notes.reactions.create(
+              NotesReactionsCreateRequest(noteId: note.id, reaction: "👍"));
+        });
+
+        test("delete", () async {
+          final note = await createNote(userClient);
+          await userClient.notes.reactions.create(
+              NotesReactionsCreateRequest(noteId: note.id, reaction: "👍"));
+          await userClient.notes.reactions
+              .delete(NotesReactionsDeleteRequest(noteId: note.id));
+        });
+      });
+
+      group("favorites", () {
+        test("create", () async {
+          final note = await createNote(userClient);
+          await userClient.notes.favorites
+              .create(NotesFavoritesCreateRequest(noteId: note.id));
+        });
+
+        test("delete", () async {
+          final note = await createNote(userClient);
+          await userClient.notes.favorites
+              .create(NotesFavoritesCreateRequest(noteId: note.id));
+          await userClient.notes.favorites
+              .delete(NotesFavoritesDeleteRequest(noteId: note.id));
+        });
+      });
+    });
+
+    group("renoteMute", () {
+      test("create", () async {
+        final newUser = await createUser(adminClient);
+        await userClient.renoteMute
+            .create(RenoteMuteCreateRequest(userId: newUser.id));
+      });
+
+      test("delete", () async {
+        final newUser = await createUser(adminClient);
+        await userClient.renoteMute
+            .create(RenoteMuteCreateRequest(userId: newUser.id));
+        await userClient.renoteMute
+            .delete(RenoteMuteDeleteRequest(userId: newUser.id));
+      });
+    });
+
+    group("users", () {
+      test("show", () async {
+        await userClient.users.show(UsersShowRequest(userId: user.id));
+      });
+
+      test("showByIds", () async {
+        await userClient.users
+            .showByIds(UsersShowByIdsRequest(userIds: [admin.id, user.id]));
+      });
+
+      test("showByName", () async {
+        await userClient.users
+            .showByName(UsersShowByUserNameRequest(userName: user.username));
+      });
+
+      test("notes", () async {
+        await userClient.users.notes(UsersNotesRequest(userId: user.id));
+      });
+
+      test("clips", () async {
+        await userClient.users.clips(UsersClipsRequest(userId: user.id));
+      });
+
+      test("followers", () async {
+        await userClient.users
+            .followers(UsersFollowersRequest(userId: user.id));
+      });
+
+      test("reportAbuse", () async {
+        final newUser = await createUser(adminClient);
+        await userClient.users.reportAbuse(
+            UsersReportAbuseRequest(userId: newUser.id, comment: "comment"));
+      });
+
+      group("lists", () {
+        test("create", () async {
+          await userClient.users.list
+              .create(UsersListsCreateRequest(name: "test"));
+        });
+
+        test("delete", () async {
+          final list = await userClient.users.list
+              .create(UsersListsCreateRequest(name: "test"));
+          await userClient.users.list
+              .delete(UsersListsDeleteRequest(listId: list.id));
+        });
+
+        test("list", () async {
+          await userClient.users.list.list();
+        });
+
+        test("pull", () async {
+          final list = await userClient.users.list
+              .create(UsersListsCreateRequest(name: "test"));
+          await userClient.users.list.push(UsersListsPushRequest(
+            listId: list.id,
+            userId: user.id,
+          ));
+          await userClient.users.list.pull(UsersListsPullRequest(
+            listId: list.id,
+            userId: user.id,
+          ));
+        });
+
+        test("push", () async {
+          final list = await userClient.users.list
+              .create(UsersListsCreateRequest(name: "test"));
+          await userClient.users.list.push(UsersListsPushRequest(
+            listId: list.id,
+            userId: user.id,
+          ));
+        });
+
+        test("update", () async {
+          final list = await userClient.users.list
+              .create(UsersListsCreateRequest(name: "test"));
+          await userClient.users.list.update(UsersListsUpdateRequest(
+            listId: list.id,
+            name: "updated",
+          ));
+        });
+      });
+    });
+    group("misc", () {
+      test("announcements", () async {
+        userClient.announcements(AnnouncementsRequest());
+      });
+
+      test("endpoints", () async {
+        userClient.endpoints();
+      });
+
+      test("emojis", () async {
+        userClient.emojis();
+      });
+
+      test("meta", () async {
+        userClient.meta();
+      });
+    });
+  });
+
+  group("Streaming tests", () {
+    test("homeTimeline", () async {
+      final completer = Completer<Note>();
+      final controller = userClient.homeTimelineStream(
+        completer.complete,
+        (id, reaction) => null,
+      );
+      await controller.startStreaming();
+      await userClient.notes.create(NotesCreateRequest(text: "test"));
+      await completer.future;
+      await controller.disconnect();
+    });
+
+    test("localTimeline", () async {
+      final completer = Completer<Note>();
+      final controller = userClient.localTimelineStream(
+        completer.complete,
+        (id, reaction) => null,
+      );
+      await controller.startStreaming();
+      await userClient.notes.create(NotesCreateRequest(text: "test"));
+      await completer.future;
+      await controller.disconnect();
+    });
+
+    test("globalTimeline", () async {
+      final completer = Completer<Note>();
+      final controller = userClient.globalTimelineStream(
+        completer.complete,
+      );
+      await controller.startStreaming();
+      await userClient.notes.create(NotesCreateRequest(text: "test"));
+      await completer.future;
+      await controller.disconnect();
+    });
+
+    test("hybridTimeline", () async {
+      final completer = Completer<Note>();
+      final controller = userClient.hybridTimelineStream(
+        completer.complete,
+        (id, reaction) => null,
+      );
+      await controller.startStreaming();
+      await userClient.notes.create(NotesCreateRequest(text: "test"));
+      await completer.future;
+      await controller.disconnect();
+    });
+
+    test("channel", () async {});
+
+    group("userList", () {
+      test("note", () async {
+        final completer = Completer<Note>();
+        final list = await userClient.users.list
+            .create(UsersListsCreateRequest(name: "test"));
+        await userClient.users.list.push(UsersListsPushRequest(
+          listId: list.id,
+          userId: user.id,
+        ));
+        final controller = userClient.userListStream(
+          list.id,
+          completer.complete,
+          (id, reaction) => null,
+        );
+        await controller.startStreaming();
+        await userClient.notes.create(NotesCreateRequest(text: "test"));
+        await completer.future;
+        await controller.disconnect();
+      });
+
+      test("userAdded", () async {
+        final completer = Completer<User>();
+        final list = await userClient.users.list
+            .create(UsersListsCreateRequest(name: "test"));
+        final controller = userClient.userListStream(
+          list.id,
+          (note) => null,
+          (id, reaction) => null,
+          onUserAdded: completer.complete,
+        );
+        await controller.startStreaming();
+        await userClient.users.list.push(UsersListsPushRequest(
+          listId: list.id,
+          userId: user.id,
+        ));
+        await completer.future;
+        await controller.disconnect();
+      });
+
+      test("userRemoved", () async {
+        final completer = Completer<User>();
+        final list = await userClient.users.list
+            .create(UsersListsCreateRequest(name: "test"));
+        await userClient.users.list.push(UsersListsPushRequest(
+          listId: list.id,
+          userId: user.id,
+        ));
+        final controller = userClient.userListStream(
+          list.id,
+          (note) => null,
+          (id, reaction) => null,
+          onUserRemoved: completer.complete,
+        );
+        await controller.startStreaming();
+        await userClient.users.list.pull(UsersListsPullRequest(
+          listId: list.id,
+          userId: user.id,
+        ));
+        await completer.future;
+        await controller.disconnect();
+      });
+    });
+
+    group("antenna", () {
+      test("note", () async {
+        final completer = Completer<Note>();
+        final antenna = await userClient.antennas.create(AntennasCreateRequest(
+          name: "test",
+          src: AntennaSource.all,
+          keywords: [
+            ["keyword"]
+          ],
+          excludeKeywords: [[]],
+          users: [],
+          caseSensitive: false,
+          withReplies: false,
+          withFile: false,
+          notify: false,
+        ));
+        final controller = userClient.antennaStream(
+          antenna.id,
+          completer.complete,
+          (id, reaction) => null,
+        );
+        await controller.startStreaming();
+        await userClient.notes.create(NotesCreateRequest(text: "keyword"));
+        await completer.future;
+        await controller.disconnect();
+      });
+    });
+
+    group("main", () {
+      test("renote", () async {
+        final completer = Completer<void>();
+        final note = await createNote(userClient);
+        final controller = userClient.mainStream(onRenote: completer.complete);
+        await controller.startStreaming();
+        await adminClient.notes.create(NotesCreateRequest(
+          text: "reply",
+          renoteId: note.id,
+        ));
+        await completer.future;
+        await controller.disconnect();
+      });
+    });
   });
 }

--- a/test/misskey_dart_test.dart
+++ b/test/misskey_dart_test.dart
@@ -458,19 +458,19 @@ void main() async {
     });
     group("misc", () {
       test("announcements", () async {
-        userClient.announcements(AnnouncementsRequest());
+        await userClient.announcements(AnnouncementsRequest());
       });
 
       test("endpoints", () async {
-        userClient.endpoints();
+        await userClient.endpoints();
       });
 
       test("emojis", () async {
-        userClient.emojis();
+        await userClient.emojis();
       });
 
       test("meta", () async {
-        userClient.meta();
+        await userClient.meta();
       });
     });
   });

--- a/test/misskey_dart_test.dart
+++ b/test/misskey_dart_test.dart
@@ -27,24 +27,26 @@ Misskey getTestClient(String token) {
   );
 }
 
-Future<CreateUserResponse> createUser(Misskey adminClient) async {
-  final response = await adminClient.apiService.post<Map<String, dynamic>>(
-    "admin/accounts/create",
-    {
-      "username": Uuid().v4().replaceAll("-", "").substring(0, 20),
-      "password": "test",
-    },
-  );
-  return CreateUserResponse(
-    client: getTestClient(response["token"]),
-    user: User.fromJson(response),
-  );
-}
+extension on Misskey {
+  Future<CreateUserResponse> createUser() async {
+    final response = await apiService.post<Map<String, dynamic>>(
+      "admin/accounts/create",
+      {
+        "username": Uuid().v4().replaceAll("-", "").substring(0, 20),
+        "password": "test",
+      },
+    );
+    return CreateUserResponse(
+      client: getTestClient(response["token"]),
+      user: User.fromJson(response),
+    );
+  }
 
-Future<Note> createNote(Misskey client) async {
-  final response = await client.apiService
-      .post<Map<String, dynamic>>("notes/create", {"text": "test"});
-  return Note.fromJson(response["createdNote"]);
+  Future<Note> createNote() async {
+    final response = await apiService
+        .post<Map<String, dynamic>>("notes/create", {"text": "test"});
+    return Note.fromJson(response["createdNote"]);
+  }
 }
 
 void main() async {
@@ -57,35 +59,39 @@ void main() async {
   group("API tests", () {
     group("antennas", () {
       test("create", () async {
-        await userClient.antennas.create(AntennasCreateRequest(
-          name: "test",
-          src: AntennaSource.all,
-          keywords: [
-            ["keyword"]
-          ],
-          excludeKeywords: [[]],
-          users: [],
-          caseSensitive: false,
-          withReplies: false,
-          withFile: false,
-          notify: false,
-        ));
+        await userClient.antennas.create(
+          AntennasCreateRequest(
+            name: "test",
+            src: AntennaSource.all,
+            keywords: [
+              ["keyword"]
+            ],
+            excludeKeywords: [[]],
+            users: [],
+            caseSensitive: false,
+            withReplies: false,
+            withFile: false,
+            notify: false,
+          ),
+        );
       });
 
       test("delete", () async {
-        final antenna = await userClient.antennas.create(AntennasCreateRequest(
-          name: "test",
-          src: AntennaSource.all,
-          keywords: [
-            ["keyword"]
-          ],
-          excludeKeywords: [[]],
-          users: [],
-          caseSensitive: false,
-          withReplies: false,
-          withFile: false,
-          notify: false,
-        ));
+        final antenna = await userClient.antennas.create(
+          AntennasCreateRequest(
+            name: "test",
+            src: AntennaSource.all,
+            keywords: [
+              ["keyword"]
+            ],
+            excludeKeywords: [[]],
+            users: [],
+            caseSensitive: false,
+            withReplies: false,
+            withFile: false,
+            notify: false,
+          ),
+        );
         await userClient.antennas
             .delete(AntennasDeleteRequest(antennaId: antenna.id));
       });
@@ -95,81 +101,89 @@ void main() async {
       });
 
       test("notes", () async {
-        final antenna = await userClient.antennas.create(AntennasCreateRequest(
-          name: "test",
-          src: AntennaSource.all,
-          keywords: [
-            ["keyword"]
-          ],
-          excludeKeywords: [[]],
-          users: [],
-          caseSensitive: false,
-          withReplies: false,
-          withFile: false,
-          notify: false,
-        ));
+        final antenna = await userClient.antennas.create(
+          AntennasCreateRequest(
+            name: "test",
+            src: AntennaSource.all,
+            keywords: [
+              ["keyword"]
+            ],
+            excludeKeywords: [[]],
+            users: [],
+            caseSensitive: false,
+            withReplies: false,
+            withFile: false,
+            notify: false,
+          ),
+        );
         await userClient.antennas
             .notes(AntennasNotesRequest(antennaId: antenna.id));
       });
 
       test("show", () async {
-        final antenna = await userClient.antennas.create(AntennasCreateRequest(
-          name: "test",
-          src: AntennaSource.all,
-          keywords: [
-            ["keyword"]
-          ],
-          excludeKeywords: [[]],
-          users: [],
-          caseSensitive: false,
-          withReplies: false,
-          withFile: false,
-          notify: false,
-        ));
+        final antenna = await userClient.antennas.create(
+          AntennasCreateRequest(
+            name: "test",
+            src: AntennaSource.all,
+            keywords: [
+              ["keyword"]
+            ],
+            excludeKeywords: [[]],
+            users: [],
+            caseSensitive: false,
+            withReplies: false,
+            withFile: false,
+            notify: false,
+          ),
+        );
         await userClient.antennas
             .show(AntennasShowRequest(antennaId: antenna.id));
       });
 
       test("update", () async {
-        final antenna = await userClient.antennas.create(AntennasCreateRequest(
-          name: "test",
-          src: AntennaSource.all,
-          keywords: [
-            ["keyword"]
-          ],
-          excludeKeywords: [[]],
-          users: [],
-          caseSensitive: false,
-          withReplies: false,
-          withFile: false,
-          notify: false,
-        ));
-        await userClient.antennas.update(AntennasUpdateRequest(
-          antennaId: antenna.id,
-          name: "updated",
-          src: AntennaSource.users,
-          keywords: [[]],
-          excludeKeywords: [
-            ["keyword"]
-          ],
-          users: ["@admin"],
-          caseSensitive: true,
-          withReplies: true,
-          withFile: true,
-          notify: true,
-        ));
+        final antenna = await userClient.antennas.create(
+          AntennasCreateRequest(
+            name: "test",
+            src: AntennaSource.all,
+            keywords: [
+              ["keyword"]
+            ],
+            excludeKeywords: [[]],
+            users: [],
+            caseSensitive: false,
+            withReplies: false,
+            withFile: false,
+            notify: false,
+          ),
+        );
+        await userClient.antennas.update(
+          AntennasUpdateRequest(
+            antennaId: antenna.id,
+            name: "updated",
+            src: AntennaSource.users,
+            keywords: [[]],
+            excludeKeywords: [
+              ["keyword"]
+            ],
+            users: ["@admin"],
+            caseSensitive: true,
+            withReplies: true,
+            withFile: true,
+            notify: true,
+          ),
+        );
       });
     });
 
     group("blocking", () {
       test("create", () async {
-        final newUser = (await createUser(adminClient)).user;
+        final newUser = (await adminClient.createUser()).user;
         await userClient.blocking
             .create(BlockCreateRequest(userId: newUser.id));
       });
 
       test("delete", () async {
-        final newUser = (await createUser(adminClient)).user;
+        final newUser = (await adminClient.createUser()).user;
         await userClient.blocking
             .create(BlockCreateRequest(userId: newUser.id));
         await userClient.blocking
@@ -206,13 +220,13 @@ void main() async {
 
     group("following", () {
       test("create", () async {
-        final newUser = (await createUser(adminClient)).user;
+        final newUser = (await adminClient.createUser()).user;
         await userClient.following
             .create(FollowingCreateRequest(userId: newUser.id));
       });
 
       test("delete", () async {
-        final newUser = (await createUser(adminClient)).user;
+        final newUser = (await adminClient.createUser()).user;
         await userClient.following
             .create(FollowingCreateRequest(userId: newUser.id));
         await userClient.following
@@ -240,12 +254,12 @@ void main() async {
 
     group("mute", () {
       test("create", () async {
-        final newUser = (await createUser(adminClient)).user;
+        final newUser = (await adminClient.createUser()).user;
         await userClient.mute.create(MuteCreateRequest(userId: newUser.id));
       });
 
       test("delete", () async {
-        final newUser = (await createUser(adminClient)).user;
+        final newUser = (await adminClient.createUser()).user;
         await userClient.mute.create(MuteCreateRequest(userId: newUser.id));
         await userClient.mute.delete(MuteDeleteRequest(userId: newUser.id));
       });
@@ -257,7 +271,7 @@ void main() async {
       });
 
       test("delete", () async {
-        final note = await createNote(userClient);
+        final note = await userClient.createNote();
         await userClient.notes.delete(NotesDeleteRequest(noteId: note.id));
       });
 
@@ -266,7 +280,7 @@ void main() async {
       });
 
       test("show", () async {
-        final note = await createNote(userClient);
+        final note = await userClient.createNote();
         await userClient.notes.show(NotesShowRequest(noteId: note.id));
       });
 
@@ -287,7 +301,7 @@ void main() async {
       });
 
       test("state", () async {
-        final note = await createNote(userClient);
+        final note = await userClient.createNote();
         await userClient.notes.state(NotesStateRequest(noteId: note.id));
       });
 
@@ -301,15 +315,17 @@ void main() async {
 
       group("reactions", () {
         test("create", () async {
-          final note = await createNote(userClient);
+          final note = await userClient.createNote();
           await userClient.notes.reactions.create(
-              NotesReactionsCreateRequest(noteId: note.id, reaction: "👍"));
+            NotesReactionsCreateRequest(noteId: note.id, reaction: "👍"),
+          );
         });
 
         test("delete", () async {
-          final note = await createNote(userClient);
+          final note = await userClient.createNote();
           await userClient.notes.reactions.create(
-              NotesReactionsCreateRequest(noteId: note.id, reaction: "👍"));
+            NotesReactionsCreateRequest(noteId: note.id, reaction: "👍"),
+          );
           await userClient.notes.reactions
               .delete(NotesReactionsDeleteRequest(noteId: note.id));
         });
@@ -317,13 +333,13 @@ void main() async {
 
       group("favorites", () {
         test("create", () async {
-          final note = await createNote(userClient);
+          final note = await userClient.createNote();
           await userClient.notes.favorites
               .create(NotesFavoritesCreateRequest(noteId: note.id));
         });
 
         test("delete", () async {
-          final note = await createNote(userClient);
+          final note = await userClient.createNote();
           await userClient.notes.favorites
               .create(NotesFavoritesCreateRequest(noteId: note.id));
           await userClient.notes.favorites
@@ -334,13 +350,13 @@ void main() async {
 
     group("renoteMute", () {
       test("create", () async {
-        final newUser = (await createUser(adminClient)).user;
+        final newUser = (await adminClient.createUser()).user;
         await userClient.renoteMute
             .create(RenoteMuteCreateRequest(userId: newUser.id));
       });
 
       test("delete", () async {
-        final newUser = (await createUser(adminClient)).user;
+        final newUser = (await adminClient.createUser()).user;
         await userClient.renoteMute
             .create(RenoteMuteCreateRequest(userId: newUser.id));
         await userClient.renoteMute
@@ -377,9 +393,10 @@ void main() async {
       });
 
       test("reportAbuse", () async {
-        final newUser = (await createUser(adminClient)).user;
+        final newUser = (await adminClient.createUser()).user;
         await userClient.users.reportAbuse(
-            UsersReportAbuseRequest(userId: newUser.id, comment: "comment"));
+          UsersReportAbuseRequest(userId: newUser.id, comment: "comment"),
+        );
       });
 
       group("lists", () {
@@ -402,32 +419,40 @@ void main() async {
         test("pull", () async {
           final list = await userClient.users.list
               .create(UsersListsCreateRequest(name: "test"));
-          await userClient.users.list.push(UsersListsPushRequest(
-            listId: list.id,
-            userId: user.id,
-          ));
-          await userClient.users.list.pull(UsersListsPullRequest(
-            listId: list.id,
-            userId: user.id,
-          ));
+          await userClient.users.list.push(
+            UsersListsPushRequest(
+              listId: list.id,
+              userId: user.id,
+            ),
+          );
+          await userClient.users.list.pull(
+            UsersListsPullRequest(
+              listId: list.id,
+              userId: user.id,
+            ),
+          );
         });
 
         test("push", () async {
           final list = await userClient.users.list
               .create(UsersListsCreateRequest(name: "test"));
-          await userClient.users.list.push(UsersListsPushRequest(
-            listId: list.id,
-            userId: user.id,
-          ));
+          await userClient.users.list.push(
+            UsersListsPushRequest(
+              listId: list.id,
+              userId: user.id,
+            ),
+          );
         });
 
         test("update", () async {
           final list = await userClient.users.list
               .create(UsersListsCreateRequest(name: "test"));
-          await userClient.users.list.update(UsersListsUpdateRequest(
-            listId: list.id,
-            name: "updated",
-          ));
+          await userClient.users.list.update(
+            UsersListsUpdateRequest(
+              listId: list.id,
+              name: "updated",
+            ),
+          );
         });
       });
     });
@@ -505,10 +530,12 @@ void main() async {
         final completer = Completer<Note>();
         final list = await userClient.users.list
             .create(UsersListsCreateRequest(name: "test"));
-        await userClient.users.list.push(UsersListsPushRequest(
-          listId: list.id,
-          userId: user.id,
-        ));
+        await userClient.users.list.push(
+          UsersListsPushRequest(
+            listId: list.id,
+            userId: user.id,
+          ),
+        );
         final controller = userClient.userListStream(
           list.id,
           completer.complete,
@@ -531,10 +558,12 @@ void main() async {
           onUserAdded: completer.complete,
         );
         await controller.startStreaming();
-        await userClient.users.list.push(UsersListsPushRequest(
-          listId: list.id,
-          userId: user.id,
-        ));
+        await userClient.users.list.push(
+          UsersListsPushRequest(
+            listId: list.id,
+            userId: user.id,
+          ),
+        );
         await completer.future;
         await controller.disconnect();
       });
@@ -543,10 +572,12 @@ void main() async {
         final completer = Completer<User>();
         final list = await userClient.users.list
             .create(UsersListsCreateRequest(name: "test"));
-        await userClient.users.list.push(UsersListsPushRequest(
-          listId: list.id,
-          userId: user.id,
-        ));
+        await userClient.users.list.push(
+          UsersListsPushRequest(
+            listId: list.id,
+            userId: user.id,
+          ),
+        );
         final controller = userClient.userListStream(
           list.id,
           (note) => null,
@@ -554,10 +585,12 @@ void main() async {
           onUserRemoved: completer.complete,
         );
         await controller.startStreaming();
-        await userClient.users.list.pull(UsersListsPullRequest(
-          listId: list.id,
-          userId: user.id,
-        ));
+        await userClient.users.list.pull(
+          UsersListsPullRequest(
+            listId: list.id,
+            userId: user.id,
+          ),
+        );
         await completer.future;
         await controller.disconnect();
       });
@@ -566,19 +599,21 @@ void main() async {
     group("antenna", () {
       test("note", () async {
         final completer = Completer<Note>();
-        final antenna = await userClient.antennas.create(AntennasCreateRequest(
-          name: "test",
-          src: AntennaSource.all,
-          keywords: [
-            ["keyword"]
-          ],
-          excludeKeywords: [[]],
-          users: [],
-          caseSensitive: false,
-          withReplies: false,
-          withFile: false,
-          notify: false,
-        ));
+        final antenna = await userClient.antennas.create(
+          AntennasCreateRequest(
+            name: "test",
+            src: AntennaSource.all,
+            keywords: [
+              ["keyword"]
+            ],
+            excludeKeywords: [[]],
+            users: [],
+            caseSensitive: false,
+            withReplies: false,
+            withFile: false,
+            notify: false,
+          ),
+        );
         final controller = userClient.antennaStream(
           antenna.id,
           completer.complete,
@@ -594,12 +629,14 @@ void main() async {
     group("main", () {
       test("renote", () async {
         final completer = Completer<void>();
-        final note = await createNote(userClient);
+        final note = await userClient.createNote();
         final controller = userClient.mainStream(onRenote: completer.complete);
         await controller.startStreaming();
-        await adminClient.notes.create(NotesCreateRequest(
-          renoteId: note.id,
-        ));
+        await adminClient.notes.create(
+          NotesCreateRequest(
+            renoteId: note.id,
+          ),
+        );
         await completer.future;
         await controller.disconnect();
       });

--- a/test/testenv/.config/default.yml
+++ b/test/testenv/.config/default.yml
@@ -1,0 +1,179 @@
+#━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Misskey configuration
+#━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+#   ┌─────┐
+#───┘ URL └─────────────────────────────────────────────────────
+
+# Final accessible URL seen by a user.
+url: http://localhost:3000
+
+# ONCE YOU HAVE STARTED THE INSTANCE, DO NOT CHANGE THE
+# URL SETTINGS AFTER THAT!
+
+#   ┌───────────────────────┐
+#───┘ Port and TLS settings └───────────────────────────────────
+
+#
+# Misskey requires a reverse proxy to support HTTPS connections.
+#
+#                 +----- https://example.tld/ ------------+
+#   +------+      |+-------------+      +----------------+|
+#   | User | ---> || Proxy (443) | ---> | Misskey (3000) ||
+#   +------+      |+-------------+      +----------------+|
+#                 +---------------------------------------+
+#
+#   You need to set up a reverse proxy. (e.g. nginx)
+#   An encrypted connection with HTTPS is highly recommended
+#   because tokens may be transferred in GET requests.
+
+# The port that your Misskey server should listen on.
+port: 3000
+
+#   ┌──────────────────────────┐
+#───┘ PostgreSQL configuration └────────────────────────────────
+
+db:
+  host: db
+  port: 5432
+
+  # Database name
+  db: misskey
+
+  # Auth
+  user: misskey-test
+  pass: misskey-test
+
+  # Whether disable Caching queries
+  #disableCache: true
+
+  # Extra Connection options
+  #extra:
+  #  ssl: true
+
+dbReplications: false
+
+# You can configure any number of replicas here
+#dbSlaves:
+#  -
+#    host:
+#    port:
+#    db:
+#    user:
+#    pass:
+#  -
+#    host:
+#    port:
+#    db:
+#    user:
+#    pass:
+
+#   ┌─────────────────────┐
+#───┘ Redis configuration └─────────────────────────────────────
+
+redis:
+  host: redis
+  port: 6379
+  #family: 0  # 0=Both, 4=IPv4, 6=IPv6
+  #pass: example-pass
+  #prefix: example-prefix
+  #db: 1
+
+#redisForPubsub:
+#  host: redis
+#  port: 6379
+#  #family: 0  # 0=Both, 4=IPv4, 6=IPv6
+#  #pass: example-pass
+#  #prefix: example-prefix
+#  #db: 1
+
+#redisForJobQueue:
+#  host: redis
+#  port: 6379
+#  #family: 0  # 0=Both, 4=IPv4, 6=IPv6
+#  #pass: example-pass
+#  #prefix: example-prefix
+#  #db: 1
+
+#   ┌───────────────────────────┐
+#───┘ MeiliSearch configuration └─────────────────────────────
+
+#meilisearch:
+#  host: meilisearch
+#  port: 7700
+#  apiKey: ''
+#  ssl: true
+#  index: ''
+
+#   ┌───────────────┐
+#───┘ ID generation └───────────────────────────────────────────
+
+# You can select the ID generation method.
+# You don't usually need to change this setting, but you can
+# change it according to your preferences.
+
+# Available methods:
+# aid ... Short, Millisecond accuracy
+# meid ... Similar to ObjectID, Millisecond accuracy
+# ulid ... Millisecond accuracy
+# objectid ... This is left for backward compatibility
+
+# ONCE YOU HAVE STARTED THE INSTANCE, DO NOT CHANGE THE
+# ID SETTINGS AFTER THAT!
+
+id: 'aid'
+
+#   ┌─────────────────────┐
+#───┘ Other configuration └─────────────────────────────────────
+
+# Whether disable HSTS
+#disableHsts: true
+
+# Number of worker processes
+#clusterLimit: 1
+
+# Job concurrency per worker
+# deliverJobConcurrency: 128
+# inboxJobConcurrency: 16
+
+# Job rate limiter
+# deliverJobPerSec: 128
+# inboxJobPerSec: 16
+
+# Job attempts
+# deliverJobMaxAttempts: 12
+# inboxJobMaxAttempts: 8
+
+# IP address family used for outgoing request (ipv4, ipv6 or dual)
+#outgoingAddressFamily: ipv4
+
+# Proxy for HTTP/HTTPS
+#proxy: http://127.0.0.1:3128
+
+proxyBypassHosts:
+  - api.deepl.com
+  - api-free.deepl.com
+  - www.recaptcha.net
+  - hcaptcha.com
+  - challenges.cloudflare.com
+
+# Proxy for SMTP/SMTPS
+#proxySmtp: http://127.0.0.1:3128   # use HTTP/1.1 CONNECT
+#proxySmtp: socks4://127.0.0.1:1080 # use SOCKS4
+#proxySmtp: socks5://127.0.0.1:1080 # use SOCKS5
+
+# Media Proxy
+#mediaProxy: https://example.com/proxy
+
+# Proxy remote files (default: false)
+#proxyRemoteFiles: true
+
+# Sign to ActivityPub GET request (default: true)
+signToActivityPubGet: true
+
+#allowedPrivateNetworks: [
+#  '127.0.0.1/32'
+#]
+
+# Upload or download file size limits (bytes)
+#maxFileSize: 262144000

--- a/test/testenv/docker-compose.yml
+++ b/test/testenv/docker-compose.yml
@@ -1,0 +1,75 @@
+version: "3"
+
+services:
+  get-token:
+    build: get-token
+    depends_on:
+      - web
+    networks:
+      - internal_network
+    volumes:
+      - ../:/misskey-test
+
+  web:
+    image: misskey/misskey:13.12.2
+    restart: always
+    links:
+      - db
+      - redis
+#     - meilisearch
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+    networks:
+      - internal_network
+      - external_network
+    volumes:
+      - ./.config:/misskey/.config
+    environment:
+      - NODE_ENV=development
+
+  redis:
+    restart: always
+    image: redis:7-alpine
+    networks:
+      - internal_network
+    healthcheck:
+      test: "redis-cli ping"
+      interval: 5s
+      retries: 20
+
+  db:
+    restart: always
+    image: postgres:15-alpine
+    networks:
+      - internal_network
+    environment:
+      - POSTGRES_PASSWORD=misskey-test
+      - POSTGRES_USER=misskey-test
+      - POSTGRES_DB=misskey
+    healthcheck:
+      test: "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"
+      interval: 5s
+      retries: 20
+
+#  meilisearch:
+#    restart: always
+#    image: getmeili/meilisearch:v1.1.1
+#    environment:
+#      - MEILI_NO_ANALYTICS=true
+#      - MEILI_ENV=production
+#    env_file:
+#      - .config/meilisearch.env
+#    networks:
+#      - internal_network
+#    volumes:
+#      - ./meili_data:/meili_data
+
+networks:
+  internal_network:
+    internal: true
+  external_network:

--- a/test/testenv/get-token/Dockerfile
+++ b/test/testenv/get-token/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.12
+
+RUN apk add --no-cache jq curl
+COPY get-token.sh /get-token.sh
+
+CMD ["/get-token.sh"]

--- a/test/testenv/get-token/get-token.sh
+++ b/test/testenv/get-token/get-token.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+
+until nc -z web 3000; do
+  sleep 1
+done
+
+ADMIN_DATA=$(
+  curl -fsS -XPOST -H 'Content-Type: application/json' \
+    --data '{"username":"admin","password":"admin"}'   \
+    http://web:3000/api/admin/accounts/create
+)
+
+ADMIN_TOKEN=$(echo "$ADMIN_DATA" | jq -r .token)
+ADMIN_ID=$(echo "$ADMIN_DATA" | jq -r .id)
+
+USER_DATA=$(
+  curl -fsS -XPOST -H 'Content-Type: application/json'     \
+    --data '{"username":"testuser","password":"testuser"}' \
+    http://web:3000/api/signup
+)
+
+USER_TOKEN=$(echo "$USER_DATA" | jq -r .token)
+USER_ID=$(echo "$USER_DATA" | jq -r .id)
+
+(
+  ROLE_ID=$(
+    curl -fsS -XPOST -H 'Content-Type: application/json' \
+      --data '{
+        "i": "'"${ADMIN_TOKEN}"'",
+        "name": "test",
+        "description": "",
+        "color": "",
+        "iconUrl": null,
+        "target": "manual",
+        "condFormula": {},
+        "isPublic": false,
+        "isModerator": false,
+        "isAdministrator": false,
+        "asBadge": false,
+        "canEditMembersByModerator": false,
+        "displayOrder": 0,
+        "policies": {
+          "canSearchNotes": {
+            "value": true,
+            "priority": 0,
+            "useDefault": false
+          },
+          "pinLimit": {
+            "value": 1000,
+            "priority": 0,
+            "useDefault": false
+          },
+          "clipLimit": {
+            "value": 1000,
+            "priority": 0,
+            "useDefault": false
+          },
+          "antennaLimit": {
+            "value": 1000,
+            "priority": 0,
+            "useDefault": false
+          },
+          "userListLimit": {
+            "value": 1000,
+            "priority": 0,
+            "useDefault": false
+          }
+        }
+      }' \
+    http://web:3000/api/admin/roles/create | jq -r .id \
+  ) &&
+  curl -fsS -XPOST -H 'Content-Type: application/json' \
+    --data '{"i":"'"${ADMIN_TOKEN}"'", "roleId": "'"${ROLE_ID}"'", "userId":"'"${ADMIN_ID}"'"}' \
+    http://web:3000/api/admin/roles/assign &&
+  curl -fsS -XPOST -H 'Content-Type: application/json' \
+    --data '{"i":"'"${ADMIN_TOKEN}"'", "roleId": "'"${ROLE_ID}"'", "userId":"'"${USER_ID}"'"}' \
+    http://web:3000/api/admin/roles/assign
+) || exit 1
+
+ENV_FILE="/misskey-test/.env"
+
+if [ ! -e $ENV_FILE ]; then
+  cp /misskey-test/.env.example $ENV_FILE
+fi
+
+sed -i "/TEST_ADMIN_TOKEN.*/cTEST_ADMIN_TOKEN=${ADMIN_TOKEN}" $ENV_FILE
+sed -i "/TEST_USER_TOKEN.*/cTEST_USER_TOKEN=${USER_TOKEN}" $ENV_FILE

--- a/test/testenv/setup.sh
+++ b/test/testenv/setup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eu
+
+cd "$(dirname -- "$0")"
+
+readonly MAX_RETRY=5
+
+count=0
+while :; do
+  docker compose build
+  docker compose run --rm web pnpm run init
+  docker compose up -d web
+  if docker compose run --rm get-token; then
+    break
+  fi
+
+  if [ $(( count++ )) -ge $MAX_RETRY ]; then
+    echo "Too many fails"
+    exit 1
+  else
+    echo "Retrying... (count: $count)"
+    docker compose down -v
+  fi
+done


### PR DESCRIPTION
APIを追加するときに手元でテストできたら便利だと思ったのでテストを作りました

全体的に[misskey-rs](https://github.com/coord-e/misskey-rs)のテストを参考にしています

## 使い方

`test/testenv/setup.sh` を実行するとdocker上でmisskeyが立ち上がり, `test/.env` にトークンなどが書き込まれます

その後 `dart test` を実行することで `test/.env` を読んでテストが実行されます

## 変更点

クライアントを作成する際にURLを指定することでhttpのサーバーにも対応できるようにしました (2d0d2c1babab04069d9269d4f905792583b8315d)