### PR TITLE
AnnouncementsResponseのcreatedAtをnullableに

### DIFF
--- a/lib/src/data/announcements_response.dart
+++ b/lib/src/data/announcements_response.dart
@@ -11,7 +11,7 @@ part 'announcements_response.g.dart';
 class AnnouncementsResponse with _$AnnouncementsResponse {
   const factory AnnouncementsResponse({
     required String id,
-    @DateTimeConverter() required DateTime createdAt,
+    @NullableDateTimeConverter() DateTime? createdAt,
     @NullableDateTimeConverter() DateTime? updatedAt,
     required String text,
     required String title,

--- a/lib/src/data/announcements_response.freezed.dart
+++ b/lib/src/data/announcements_response.freezed.dart
@@ -22,8 +22,8 @@ AnnouncementsResponse _$AnnouncementsResponseFromJson(
 /// @nodoc
 mixin _$AnnouncementsResponse {
   String get id => throw _privateConstructorUsedError;
-  @DateTimeConverter()
-  DateTime get createdAt => throw _privateConstructorUsedError;
+  @NullableDateTimeConverter()
+  DateTime? get createdAt => throw _privateConstructorUsedError;
   @NullableDateTimeConverter()
   DateTime? get updatedAt => throw _privateConstructorUsedError;
   String get text => throw _privateConstructorUsedError;
@@ -52,7 +52,7 @@ abstract class $AnnouncementsResponseCopyWith<$Res> {
   @useResult
   $Res call(
       {String id,
-      @DateTimeConverter() DateTime createdAt,
+      @NullableDateTimeConverter() DateTime? createdAt,
       @NullableDateTimeConverter() DateTime? updatedAt,
       String text,
       String title,
@@ -81,7 +81,7 @@ class _$AnnouncementsResponseCopyWithImpl<$Res,
   @override
   $Res call({
     Object? id = null,
-    Object? createdAt = null,
+    Object? createdAt = freezed,
     Object? updatedAt = freezed,
     Object? text = null,
     Object? title = null,
@@ -99,10 +99,10 @@ class _$AnnouncementsResponseCopyWithImpl<$Res,
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as String,
-      createdAt: null == createdAt
+      createdAt: freezed == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
+              as DateTime?,
       updatedAt: freezed == updatedAt
           ? _value.updatedAt
           : updatedAt // ignore: cast_nullable_to_non_nullable
@@ -161,7 +161,7 @@ abstract class _$$_AnnouncementsResponseCopyWith<$Res>
   @useResult
   $Res call(
       {String id,
-      @DateTimeConverter() DateTime createdAt,
+      @NullableDateTimeConverter() DateTime? createdAt,
       @NullableDateTimeConverter() DateTime? updatedAt,
       String text,
       String title,
@@ -187,7 +187,7 @@ class __$$_AnnouncementsResponseCopyWithImpl<$Res>
   @override
   $Res call({
     Object? id = null,
-    Object? createdAt = null,
+    Object? createdAt = freezed,
     Object? updatedAt = freezed,
     Object? text = null,
     Object? title = null,
@@ -205,10 +205,10 @@ class __$$_AnnouncementsResponseCopyWithImpl<$Res>
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as String,
-      createdAt: null == createdAt
+      createdAt: freezed == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
+              as DateTime?,
       updatedAt: freezed == updatedAt
           ? _value.updatedAt
           : updatedAt // ignore: cast_nullable_to_non_nullable
@@ -262,7 +262,7 @@ class __$$_AnnouncementsResponseCopyWithImpl<$Res>
 class _$_AnnouncementsResponse implements _AnnouncementsResponse {
   const _$_AnnouncementsResponse(
       {required this.id,
-      @DateTimeConverter() required this.createdAt,
+      @NullableDateTimeConverter() this.createdAt,
       @NullableDateTimeConverter() this.updatedAt,
       required this.text,
       required this.title,
@@ -281,8 +281,8 @@ class _$_AnnouncementsResponse implements _AnnouncementsResponse {
   @override
   final String id;
   @override
-  @DateTimeConverter()
-  final DateTime createdAt;
+  @NullableDateTimeConverter()
+  final DateTime? createdAt;
   @override
   @NullableDateTimeConverter()
   final DateTime? updatedAt;
@@ -375,7 +375,7 @@ class _$_AnnouncementsResponse implements _AnnouncementsResponse {
 abstract class _AnnouncementsResponse implements AnnouncementsResponse {
   const factory _AnnouncementsResponse(
       {required final String id,
-      @DateTimeConverter() required final DateTime createdAt,
+      @NullableDateTimeConverter() final DateTime? createdAt,
       @NullableDateTimeConverter() final DateTime? updatedAt,
       required final String text,
       required final String title,
@@ -394,8 +394,8 @@ abstract class _AnnouncementsResponse implements AnnouncementsResponse {
   @override
   String get id;
   @override
-  @DateTimeConverter()
-  DateTime get createdAt;
+  @NullableDateTimeConverter()
+  DateTime? get createdAt;
   @override
   @NullableDateTimeConverter()
   DateTime? get updatedAt;

--- a/lib/src/data/announcements_response.g.dart
+++ b/lib/src/data/announcements_response.g.dart
@@ -10,8 +10,8 @@ _$_AnnouncementsResponse _$$_AnnouncementsResponseFromJson(
         Map<String, dynamic> json) =>
     _$_AnnouncementsResponse(
       id: json['id'] as String,
-      createdAt:
-          const DateTimeConverter().fromJson(json['createdAt'] as String),
+      createdAt: _$JsonConverterFromJson<String, DateTime?>(
+          json['createdAt'], const NullableDateTimeConverter().fromJson),
       updatedAt: _$JsonConverterFromJson<String, DateTime?>(
           json['updatedAt'], const NullableDateTimeConverter().fromJson),
       text: json['text'] as String,
@@ -32,7 +32,7 @@ Map<String, dynamic> _$$_AnnouncementsResponseToJson(
         _$_AnnouncementsResponse instance) =>
     <String, dynamic>{
       'id': instance.id,
-      'createdAt': const DateTimeConverter().toJson(instance.createdAt),
+      'createdAt': const NullableDateTimeConverter().toJson(instance.createdAt),
       'updatedAt': const NullableDateTimeConverter().toJson(instance.updatedAt),
       'text': instance.text,
       'title': instance.title,


### PR DESCRIPTION
https://github.com/misskey-dev/misskey/commit/1fa1d316969de15d6aaef1dbf0a0b95aec30e377 でデータベースからcreatedAtが削除されました
ほとんどのエンドポイントではidからDateを生成する処理が行われて以前同様のレスポンスが返ってきますが、unreadAnnouncementsを集めるところではこの処理が行われていません

https://github.com/misskey-dev/misskey/blob/develop/packages/backend/src/core/AnnouncementService.ts#L42-L63

そのため、Misskey 2023.10.2 以降では未読のお知らせがある場合、`IResponse.fromJson` が必ずエラーを起こすことになります

このPRではAnnouncementsResponseのcreatedAtをnullableにすることでこの問題を回避します