### PR TITLE
トークンが無いときにWebSocketに接続できるように

### DIFF
--- a/lib/src/services/streaming_service.dart
+++ b/lib/src/services/streaming_service.dart
@@ -36,7 +36,7 @@ class StreamingService {
 
   WebSocketChannel get webSocketChannel {
     _webSocketChannel ??= IOWebSocketChannel.connect(
-      "${streamingUrl ?? "wss://$host/streaming"}?i=$token",
+      "${streamingUrl ?? "wss://$host/streaming"}${token != null ? "?i=$token" : ""}",
       pingInterval: Duration(minutes: 1),
       connectTimeout: connectionTimeout,
     );


### PR DESCRIPTION
トークンが無い状態でWebSocketに接続しようとすると `wss://misskey.tld/streaming?i=null` が指定されるためトークンが間違っているとして接続されない問題を修正しました