### PR TITLE
testenv作成時に新規登録可能にする

### DIFF
--- a/test/testenv/get-token/get-token.sh
+++ b/test/testenv/get-token/get-token.sh
@@ -13,6 +13,10 @@ ADMIN_DATA=$(
 ADMIN_TOKEN=$(echo "$ADMIN_DATA" | jq -r .token)
 ADMIN_ID=$(echo "$ADMIN_DATA" | jq -r .id)
 
+curl -fsS -XPOST -H 'Content-Type: application/json'                \
+  --data '{"i": "'"${ADMIN_TOKEN}"'","disableRegistration": false}' \
+  http://web:3000/api/admin/update-meta
+
 USER_DATA=$(
   curl -fsS -XPOST -H 'Content-Type: application/json'     \
     --data '{"username":"testuser","password":"testuser"}' \


### PR DESCRIPTION
`https://github.com/misskey-dev/misskey/pull/13130` でユーザーの作成ができなくなっていた問題に対応しました