### PR TITLE
analyzeでinfoレベルの問題があるときに失敗するように

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
       - run: dart pub get
-      - run: dart analyze
+      - run: dart analyze --fatal-infos

--- a/lib/src/misskey_i.dart
+++ b/lib/src/misskey_i.dart
@@ -1,8 +1,4 @@
 import 'package:misskey_dart/misskey_dart.dart';
-import 'package:misskey_dart/src/data/i/registry/i_registry_get_all_request.dart';
-import 'package:misskey_dart/src/data/i/registry/i_registry_get_detail_request.dart';
-import 'package:misskey_dart/src/data/i/registry/i_registry_remove_request.dart';
-import 'package:misskey_dart/src/data/i/registry/i_registry_set_request.dart';
 import 'package:misskey_dart/src/services/api_service.dart';
 
 class MisskeyI {

--- a/lib/src/misskey_reversi.dart
+++ b/lib/src/misskey_reversi.dart
@@ -1,7 +1,4 @@
 import 'package:misskey_dart/misskey_dart.dart';
-import 'package:misskey_dart/src/data/reversi/reversi_games_request.dart';
-import 'package:misskey_dart/src/data/reversi/reversi_games_response.dart';
-import 'package:misskey_dart/src/data/reversi/reversi_show_game_response.dart';
 import 'package:misskey_dart/src/services/api_service.dart';
 
 class MisskeyReversi {

--- a/lib/src/misskey_users.dart
+++ b/lib/src/misskey_users.dart
@@ -1,6 +1,4 @@
 import 'package:misskey_dart/misskey_dart.dart';
-import 'package:misskey_dart/src/data/users/users_get_frequently_replied_users_request.dart';
-import 'package:misskey_dart/src/data/users/users_get_frequently_replied_users_response.dart';
 import 'package:misskey_dart/src/services/api_service.dart';
 
 class MisskeyUsers {


### PR DESCRIPTION
github actionsで `dart analyze` を行う際に `unnecessary_import` のようなinfoレベルの問題は表示されるだけでそのまま通過していました
`fatal-infos` オプションをつけることでinfoでも失敗するようにしました