### PR TITLE
ユーザーのフィールドを追加

### DIFF
--- a/lib/src/data/base/user.dart
+++ b/lib/src/data/base/user.dart
@@ -39,6 +39,8 @@ abstract class User {
 abstract class UserDetailed implements User {
   Uri? get url;
   Uri? get uri;
+  Uri? get movedTo;
+  List<String>? get alsoKnownAs;
   DateTime get createdAt;
   DateTime? get updatedAt;
   DateTime? get lastFetchedAt;
@@ -52,6 +54,7 @@ abstract class UserDetailed implements User {
   DateTime? get birthday;
   String? get lang;
   List<UserField>? get fields;
+  List<String> get verifiedLinks;
   int get followersCount;
   int get followingCount;
   int get notesCount;
@@ -69,6 +72,7 @@ abstract class UserDetailed implements User {
   bool get securityKeys;
   List<UserRole>? get roles;
   String? get memo;
+  String? get moderationNote;
 
   factory UserDetailed.fromJson(Map<String, Object?> json) {
     if (json.containsKey("isFollowing")) {
@@ -126,6 +130,8 @@ class UserDetailedNotMe with _$UserDetailedNotMe implements UserDetailed {
     @Default([]) List<UserBadgeRole> badgeRoles,
     @NullableUriConverter() Uri? url,
     @NullableUriConverter() Uri? uri,
+    @NullableUriConverter() Uri? movedTo,
+    List<String>? alsoKnownAs,
     @DateTimeConverter() required DateTime createdAt,
     @NullableDateTimeConverter() DateTime? updatedAt,
     @NullableDateTimeConverter() DateTime? lastFetchedAt,
@@ -139,6 +145,7 @@ class UserDetailedNotMe with _$UserDetailedNotMe implements UserDetailed {
     @NullableDateTimeConverter() DateTime? birthday,
     String? lang,
     List<UserField>? fields,
+    @Default([]) List<String> verifiedLinks,
     required int followersCount,
     required int followingCount,
     required int notesCount,
@@ -155,6 +162,7 @@ class UserDetailedNotMe with _$UserDetailedNotMe implements UserDetailed {
     required bool securityKeys,
     List<UserRole>? roles,
     String? memo,
+    String? moderationNote,
   }) = _UserDetailedNotMe;
 
   factory UserDetailedNotMe.fromJson(Map<String, Object?> json) =>
@@ -181,6 +189,8 @@ class UserDetailedNotMeWithRelations
     @Default([]) List<UserBadgeRole> badgeRoles,
     @NullableUriConverter() Uri? url,
     @NullableUriConverter() Uri? uri,
+    @NullableUriConverter() Uri? movedTo,
+    List<String>? alsoKnownAs,
     @DateTimeConverter() required DateTime createdAt,
     @NullableDateTimeConverter() DateTime? updatedAt,
     @NullableDateTimeConverter() DateTime? lastFetchedAt,
@@ -194,6 +204,7 @@ class UserDetailedNotMeWithRelations
     @NullableDateTimeConverter() DateTime? birthday,
     String? lang,
     List<UserField>? fields,
+    @Default([]) List<String> verifiedLinks,
     required int followersCount,
     required int followingCount,
     required int notesCount,
@@ -210,6 +221,7 @@ class UserDetailedNotMeWithRelations
     required bool securityKeys,
     List<UserRole>? roles,
     String? memo,
+    String? moderationNote,
     required bool isFollowing,
     required bool isFollowed,
     required bool hasPendingFollowRequestFromYou,
@@ -218,6 +230,8 @@ class UserDetailedNotMeWithRelations
     required bool isBlocked,
     required bool isMuted,
     required bool isRenoteMuted,
+    Notify? notify,
+    bool? withReplies,
   }) = _UserDetailedNotMeWithRelations;
 
   factory UserDetailedNotMeWithRelations.fromJson(Map<String, Object?> json) =>
@@ -242,6 +256,8 @@ class MeDetailed with _$MeDetailed implements UserDetailed {
     @Default([]) List<UserBadgeRole> badgeRoles,
     @NullableUriConverter() Uri? url,
     @NullableUriConverter() Uri? uri,
+    @NullableUriConverter() Uri? movedTo,
+    List<String>? alsoKnownAs,
     @DateTimeConverter() required DateTime createdAt,
     @NullableDateTimeConverter() DateTime? updatedAt,
     @NullableDateTimeConverter() DateTime? lastFetchedAt,
@@ -255,6 +271,7 @@ class MeDetailed with _$MeDetailed implements UserDetailed {
     @NullableDateTimeConverter() DateTime? birthday,
     String? lang,
     List<UserField>? fields,
+    @Default([]) List<String> verifiedLinks,
     required int followersCount,
     required int followingCount,
     required int notesCount,
@@ -271,6 +288,7 @@ class MeDetailed with _$MeDetailed implements UserDetailed {
     required bool securityKeys,
     List<UserRole>? roles,
     String? memo,
+    String? moderationNote,
     String? avatarId,
     String? bannerId,
     required bool isModerator,
@@ -281,9 +299,11 @@ class MeDetailed with _$MeDetailed implements UserDetailed {
     required bool autoSensitive,
     required bool carefulBot,
     required bool autoAcceptFollowed,
+    bool? preventAiLearning,
     required bool noCrawle,
     required bool isExplorable,
     required bool isDeleted,
+    TwoFactorBackupCodesStock? twoFactorBackupCodesStock,
     required bool hideOnlineStatus,
     required bool hasUnreadSpecifiedNotes,
     required bool hasUnreadMentions,
@@ -299,7 +319,8 @@ class MeDetailed with _$MeDetailed implements UserDetailed {
     required List<String> mutedInstances,
     @Deprecated("Deprecated in Misskey 2023.9.2")
     List<String>? mutingNotificationTypes,
-    dynamic notificationRecieveConfig,
+    @Default(NotificationRecieveConfigs())
+    NotificationRecieveConfigs notificationRecieveConfig,
     required List<String> emailNotificationTypes,
     required List<UserAchievement> achievements,
     required int loggedInDays,
@@ -416,9 +437,63 @@ class UserField with _$UserField {
       _$UserFieldFromJson(json);
 }
 
+enum Notify {
+  normal,
+  none,
+}
+
+enum TwoFactorBackupCodesStock {
+  full,
+  partial,
+  none,
+}
+
 class MuteWord {
   final String? regExp;
   final List<String>? content;
 
   const MuteWord({this.regExp, this.content});
+}
+
+@freezed
+class NotificationRecieveConfigs with _$NotificationRecieveConfigs {
+  const factory NotificationRecieveConfigs({
+    NotificationRecieveConfig? note,
+    NotificationRecieveConfig? follow,
+    NotificationRecieveConfig? mention,
+    NotificationRecieveConfig? reply,
+    NotificationRecieveConfig? renote,
+    NotificationRecieveConfig? quote,
+    NotificationRecieveConfig? reaction,
+    NotificationRecieveConfig? pollEnded,
+    NotificationRecieveConfig? receiveFollowRequest,
+    NotificationRecieveConfig? followRequestAccepted,
+    NotificationRecieveConfig? roleAssigned,
+    NotificationRecieveConfig? achievementEarned,
+    NotificationRecieveConfig? app,
+    NotificationRecieveConfig? test,
+  }) = _NotificationRecieveConfigs;
+
+  factory NotificationRecieveConfigs.fromJson(Map<String, Object?> json) =>
+      _$NotificationRecieveConfigsFromJson(json);
+}
+
+@freezed
+class NotificationRecieveConfig with _$NotificationRecieveConfig {
+  const factory NotificationRecieveConfig({
+    required String type,
+    String? userListId,
+  }) = _NotificationRecieveConfig;
+
+  factory NotificationRecieveConfig.fromJson(Map<String, Object?> json) =>
+      _$NotificationRecieveConfigFromJson(json);
+}
+
+enum NotificationRecieveConfigType {
+  all,
+  following,
+  follower,
+  mutualFollow,
+  list,
+  never,
 }

--- a/lib/src/data/base/user.freezed.dart
+++ b/lib/src/data/base/user.freezed.dart
@@ -494,6 +494,9 @@ mixin _$UserDetailedNotMe {
   Uri? get url => throw _privateConstructorUsedError;
   @NullableUriConverter()
   Uri? get uri => throw _privateConstructorUsedError;
+  @NullableUriConverter()
+  Uri? get movedTo => throw _privateConstructorUsedError;
+  List<String>? get alsoKnownAs => throw _privateConstructorUsedError;
   @DateTimeConverter()
   DateTime get createdAt => throw _privateConstructorUsedError;
   @NullableDateTimeConverter()
@@ -512,6 +515,7 @@ mixin _$UserDetailedNotMe {
   DateTime? get birthday => throw _privateConstructorUsedError;
   String? get lang => throw _privateConstructorUsedError;
   List<UserField>? get fields => throw _privateConstructorUsedError;
+  List<String> get verifiedLinks => throw _privateConstructorUsedError;
   int get followersCount => throw _privateConstructorUsedError;
   int get followingCount => throw _privateConstructorUsedError;
   int get notesCount => throw _privateConstructorUsedError;
@@ -529,6 +533,7 @@ mixin _$UserDetailedNotMe {
   bool get securityKeys => throw _privateConstructorUsedError;
   List<UserRole>? get roles => throw _privateConstructorUsedError;
   String? get memo => throw _privateConstructorUsedError;
+  String? get moderationNote => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -558,6 +563,8 @@ abstract class $UserDetailedNotMeCopyWith<$Res> {
       List<UserBadgeRole> badgeRoles,
       @NullableUriConverter() Uri? url,
       @NullableUriConverter() Uri? uri,
+      @NullableUriConverter() Uri? movedTo,
+      List<String>? alsoKnownAs,
       @DateTimeConverter() DateTime createdAt,
       @NullableDateTimeConverter() DateTime? updatedAt,
       @NullableDateTimeConverter() DateTime? lastFetchedAt,
@@ -571,6 +578,7 @@ abstract class $UserDetailedNotMeCopyWith<$Res> {
       @NullableDateTimeConverter() DateTime? birthday,
       String? lang,
       List<UserField>? fields,
+      List<String> verifiedLinks,
       int followersCount,
       int followingCount,
       int notesCount,
@@ -586,7 +594,8 @@ abstract class $UserDetailedNotMeCopyWith<$Res> {
       bool usePasswordLessLogin,
       bool securityKeys,
       List<UserRole>? roles,
-      String? memo});
+      String? memo,
+      String? moderationNote});
 
   $UserInstanceInfoCopyWith<$Res>? get instance;
 }
@@ -619,6 +628,8 @@ class _$UserDetailedNotMeCopyWithImpl<$Res, $Val extends UserDetailedNotMe>
     Object? badgeRoles = null,
     Object? url = freezed,
     Object? uri = freezed,
+    Object? movedTo = freezed,
+    Object? alsoKnownAs = freezed,
     Object? createdAt = null,
     Object? updatedAt = freezed,
     Object? lastFetchedAt = freezed,
@@ -632,6 +643,7 @@ class _$UserDetailedNotMeCopyWithImpl<$Res, $Val extends UserDetailedNotMe>
     Object? birthday = freezed,
     Object? lang = freezed,
     Object? fields = freezed,
+    Object? verifiedLinks = null,
     Object? followersCount = null,
     Object? followingCount = null,
     Object? notesCount = null,
@@ -648,6 +660,7 @@ class _$UserDetailedNotMeCopyWithImpl<$Res, $Val extends UserDetailedNotMe>
     Object? securityKeys = null,
     Object? roles = freezed,
     Object? memo = freezed,
+    Object? moderationNote = freezed,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -710,6 +723,14 @@ class _$UserDetailedNotMeCopyWithImpl<$Res, $Val extends UserDetailedNotMe>
           ? _value.uri
           : uri // ignore: cast_nullable_to_non_nullable
               as Uri?,
+      movedTo: freezed == movedTo
+          ? _value.movedTo
+          : movedTo // ignore: cast_nullable_to_non_nullable
+              as Uri?,
+      alsoKnownAs: freezed == alsoKnownAs
+          ? _value.alsoKnownAs
+          : alsoKnownAs // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -762,6 +783,10 @@ class _$UserDetailedNotMeCopyWithImpl<$Res, $Val extends UserDetailedNotMe>
           ? _value.fields
           : fields // ignore: cast_nullable_to_non_nullable
               as List<UserField>?,
+      verifiedLinks: null == verifiedLinks
+          ? _value.verifiedLinks
+          : verifiedLinks // ignore: cast_nullable_to_non_nullable
+              as List<String>,
       followersCount: null == followersCount
           ? _value.followersCount
           : followersCount // ignore: cast_nullable_to_non_nullable
@@ -826,6 +851,10 @@ class _$UserDetailedNotMeCopyWithImpl<$Res, $Val extends UserDetailedNotMe>
           ? _value.memo
           : memo // ignore: cast_nullable_to_non_nullable
               as String?,
+      moderationNote: freezed == moderationNote
+          ? _value.moderationNote
+          : moderationNote // ignore: cast_nullable_to_non_nullable
+              as String?,
     ) as $Val);
   }
 
@@ -866,6 +895,8 @@ abstract class _$$UserDetailedNotMeImplCopyWith<$Res>
       List<UserBadgeRole> badgeRoles,
       @NullableUriConverter() Uri? url,
       @NullableUriConverter() Uri? uri,
+      @NullableUriConverter() Uri? movedTo,
+      List<String>? alsoKnownAs,
       @DateTimeConverter() DateTime createdAt,
       @NullableDateTimeConverter() DateTime? updatedAt,
       @NullableDateTimeConverter() DateTime? lastFetchedAt,
@@ -879,6 +910,7 @@ abstract class _$$UserDetailedNotMeImplCopyWith<$Res>
       @NullableDateTimeConverter() DateTime? birthday,
       String? lang,
       List<UserField>? fields,
+      List<String> verifiedLinks,
       int followersCount,
       int followingCount,
       int notesCount,
@@ -894,7 +926,8 @@ abstract class _$$UserDetailedNotMeImplCopyWith<$Res>
       bool usePasswordLessLogin,
       bool securityKeys,
       List<UserRole>? roles,
-      String? memo});
+      String? memo,
+      String? moderationNote});
 
   @override
   $UserInstanceInfoCopyWith<$Res>? get instance;
@@ -926,6 +959,8 @@ class __$$UserDetailedNotMeImplCopyWithImpl<$Res>
     Object? badgeRoles = null,
     Object? url = freezed,
     Object? uri = freezed,
+    Object? movedTo = freezed,
+    Object? alsoKnownAs = freezed,
     Object? createdAt = null,
     Object? updatedAt = freezed,
     Object? lastFetchedAt = freezed,
@@ -939,6 +974,7 @@ class __$$UserDetailedNotMeImplCopyWithImpl<$Res>
     Object? birthday = freezed,
     Object? lang = freezed,
     Object? fields = freezed,
+    Object? verifiedLinks = null,
     Object? followersCount = null,
     Object? followingCount = null,
     Object? notesCount = null,
@@ -955,6 +991,7 @@ class __$$UserDetailedNotMeImplCopyWithImpl<$Res>
     Object? securityKeys = null,
     Object? roles = freezed,
     Object? memo = freezed,
+    Object? moderationNote = freezed,
   }) {
     return _then(_$UserDetailedNotMeImpl(
       id: null == id
@@ -1017,6 +1054,14 @@ class __$$UserDetailedNotMeImplCopyWithImpl<$Res>
           ? _value.uri
           : uri // ignore: cast_nullable_to_non_nullable
               as Uri?,
+      movedTo: freezed == movedTo
+          ? _value.movedTo
+          : movedTo // ignore: cast_nullable_to_non_nullable
+              as Uri?,
+      alsoKnownAs: freezed == alsoKnownAs
+          ? _value._alsoKnownAs
+          : alsoKnownAs // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -1069,6 +1114,10 @@ class __$$UserDetailedNotMeImplCopyWithImpl<$Res>
           ? _value._fields
           : fields // ignore: cast_nullable_to_non_nullable
               as List<UserField>?,
+      verifiedLinks: null == verifiedLinks
+          ? _value._verifiedLinks
+          : verifiedLinks // ignore: cast_nullable_to_non_nullable
+              as List<String>,
       followersCount: null == followersCount
           ? _value.followersCount
           : followersCount // ignore: cast_nullable_to_non_nullable
@@ -1133,6 +1182,10 @@ class __$$UserDetailedNotMeImplCopyWithImpl<$Res>
           ? _value.memo
           : memo // ignore: cast_nullable_to_non_nullable
               as String?,
+      moderationNote: freezed == moderationNote
+          ? _value.moderationNote
+          : moderationNote // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -1156,6 +1209,8 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
       final List<UserBadgeRole> badgeRoles = const [],
       @NullableUriConverter() this.url,
       @NullableUriConverter() this.uri,
+      @NullableUriConverter() this.movedTo,
+      final List<String>? alsoKnownAs,
       @DateTimeConverter() required this.createdAt,
       @NullableDateTimeConverter() this.updatedAt,
       @NullableDateTimeConverter() this.lastFetchedAt,
@@ -1169,6 +1224,7 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
       @NullableDateTimeConverter() this.birthday,
       this.lang,
       final List<UserField>? fields,
+      final List<String> verifiedLinks = const [],
       required this.followersCount,
       required this.followingCount,
       required this.notesCount,
@@ -1184,11 +1240,14 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
       required this.usePasswordLessLogin,
       required this.securityKeys,
       final List<UserRole>? roles,
-      this.memo})
+      this.memo,
+      this.moderationNote})
       : _avatarDecorations = avatarDecorations,
         _emojis = emojis,
         _badgeRoles = badgeRoles,
+        _alsoKnownAs = alsoKnownAs,
         _fields = fields,
+        _verifiedLinks = verifiedLinks,
         _pinnedNoteIds = pinnedNoteIds,
         _pinnedNotes = pinnedNotes,
         _pinnedPage = pinnedPage,
@@ -1255,6 +1314,19 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
   @NullableUriConverter()
   final Uri? uri;
   @override
+  @NullableUriConverter()
+  final Uri? movedTo;
+  final List<String>? _alsoKnownAs;
+  @override
+  List<String>? get alsoKnownAs {
+    final value = _alsoKnownAs;
+    if (value == null) return null;
+    if (_alsoKnownAs is EqualUnmodifiableListView) return _alsoKnownAs;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
   @DateTimeConverter()
   final DateTime createdAt;
   @override
@@ -1291,6 +1363,15 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
     if (_fields is EqualUnmodifiableListView) return _fields;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(value);
+  }
+
+  final List<String> _verifiedLinks;
+  @override
+  @JsonKey()
+  List<String> get verifiedLinks {
+    if (_verifiedLinks is EqualUnmodifiableListView) return _verifiedLinks;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_verifiedLinks);
   }
 
   @override
@@ -1358,10 +1439,12 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
 
   @override
   final String? memo;
+  @override
+  final String? moderationNote;
 
   @override
   String toString() {
-    return 'UserDetailedNotMe(id: $id, name: $name, username: $username, host: $host, avatarUrl: $avatarUrl, avatarBlurhash: $avatarBlurhash, avatarDecorations: $avatarDecorations, isBot: $isBot, isCat: $isCat, instance: $instance, emojis: $emojis, onlineStatus: $onlineStatus, badgeRoles: $badgeRoles, url: $url, uri: $uri, createdAt: $createdAt, updatedAt: $updatedAt, lastFetchedAt: $lastFetchedAt, bannerUrl: $bannerUrl, bannerBlurhash: $bannerBlurhash, isLocked: $isLocked, isSilenced: $isSilenced, isSuspended: $isSuspended, description: $description, location: $location, birthday: $birthday, lang: $lang, fields: $fields, followersCount: $followersCount, followingCount: $followingCount, notesCount: $notesCount, pinnedNoteIds: $pinnedNoteIds, pinnedNotes: $pinnedNotes, pinnedPageId: $pinnedPageId, pinnedPage: $pinnedPage, publicReactions: $publicReactions, ffVisibility: $ffVisibility, followersVisibility: $followersVisibility, followingVisibility: $followingVisibility, twoFactorEnabled: $twoFactorEnabled, usePasswordLessLogin: $usePasswordLessLogin, securityKeys: $securityKeys, roles: $roles, memo: $memo)';
+    return 'UserDetailedNotMe(id: $id, name: $name, username: $username, host: $host, avatarUrl: $avatarUrl, avatarBlurhash: $avatarBlurhash, avatarDecorations: $avatarDecorations, isBot: $isBot, isCat: $isCat, instance: $instance, emojis: $emojis, onlineStatus: $onlineStatus, badgeRoles: $badgeRoles, url: $url, uri: $uri, movedTo: $movedTo, alsoKnownAs: $alsoKnownAs, createdAt: $createdAt, updatedAt: $updatedAt, lastFetchedAt: $lastFetchedAt, bannerUrl: $bannerUrl, bannerBlurhash: $bannerBlurhash, isLocked: $isLocked, isSilenced: $isSilenced, isSuspended: $isSuspended, description: $description, location: $location, birthday: $birthday, lang: $lang, fields: $fields, verifiedLinks: $verifiedLinks, followersCount: $followersCount, followingCount: $followingCount, notesCount: $notesCount, pinnedNoteIds: $pinnedNoteIds, pinnedNotes: $pinnedNotes, pinnedPageId: $pinnedPageId, pinnedPage: $pinnedPage, publicReactions: $publicReactions, ffVisibility: $ffVisibility, followersVisibility: $followersVisibility, followingVisibility: $followingVisibility, twoFactorEnabled: $twoFactorEnabled, usePasswordLessLogin: $usePasswordLessLogin, securityKeys: $securityKeys, roles: $roles, memo: $memo, moderationNote: $moderationNote)';
   }
 
   @override
@@ -1391,6 +1474,9 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
                 .equals(other._badgeRoles, _badgeRoles) &&
             (identical(other.url, url) || other.url == url) &&
             (identical(other.uri, uri) || other.uri == uri) &&
+            (identical(other.movedTo, movedTo) || other.movedTo == movedTo) &&
+            const DeepCollectionEquality()
+                .equals(other._alsoKnownAs, _alsoKnownAs) &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             (identical(other.updatedAt, updatedAt) ||
@@ -1415,6 +1501,8 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
                 other.birthday == birthday) &&
             (identical(other.lang, lang) || other.lang == lang) &&
             const DeepCollectionEquality().equals(other._fields, _fields) &&
+            const DeepCollectionEquality()
+                .equals(other._verifiedLinks, _verifiedLinks) &&
             (identical(other.followersCount, followersCount) ||
                 other.followersCount == followersCount) &&
             (identical(other.followingCount, followingCount) ||
@@ -1444,7 +1532,9 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
             (identical(other.securityKeys, securityKeys) ||
                 other.securityKeys == securityKeys) &&
             const DeepCollectionEquality().equals(other._roles, _roles) &&
-            (identical(other.memo, memo) || other.memo == memo));
+            (identical(other.memo, memo) || other.memo == memo) &&
+            (identical(other.moderationNote, moderationNote) ||
+                other.moderationNote == moderationNote));
   }
 
   @JsonKey(ignore: true)
@@ -1466,6 +1556,8 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
         const DeepCollectionEquality().hash(_badgeRoles),
         url,
         uri,
+        movedTo,
+        const DeepCollectionEquality().hash(_alsoKnownAs),
         createdAt,
         updatedAt,
         lastFetchedAt,
@@ -1479,6 +1571,7 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
         birthday,
         lang,
         const DeepCollectionEquality().hash(_fields),
+        const DeepCollectionEquality().hash(_verifiedLinks),
         followersCount,
         followingCount,
         notesCount,
@@ -1494,7 +1587,8 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
         usePasswordLessLogin,
         securityKeys,
         const DeepCollectionEquality().hash(_roles),
-        memo
+        memo,
+        moderationNote
       ]);
 
   @JsonKey(ignore: true)
@@ -1529,6 +1623,8 @@ abstract class _UserDetailedNotMe implements UserDetailedNotMe {
       final List<UserBadgeRole> badgeRoles,
       @NullableUriConverter() final Uri? url,
       @NullableUriConverter() final Uri? uri,
+      @NullableUriConverter() final Uri? movedTo,
+      final List<String>? alsoKnownAs,
       @DateTimeConverter() required final DateTime createdAt,
       @NullableDateTimeConverter() final DateTime? updatedAt,
       @NullableDateTimeConverter() final DateTime? lastFetchedAt,
@@ -1542,6 +1638,7 @@ abstract class _UserDetailedNotMe implements UserDetailedNotMe {
       @NullableDateTimeConverter() final DateTime? birthday,
       final String? lang,
       final List<UserField>? fields,
+      final List<String> verifiedLinks,
       required final int followersCount,
       required final int followingCount,
       required final int notesCount,
@@ -1557,7 +1654,8 @@ abstract class _UserDetailedNotMe implements UserDetailedNotMe {
       required final bool usePasswordLessLogin,
       required final bool securityKeys,
       final List<UserRole>? roles,
-      final String? memo}) = _$UserDetailedNotMeImpl;
+      final String? memo,
+      final String? moderationNote}) = _$UserDetailedNotMeImpl;
 
   factory _UserDetailedNotMe.fromJson(Map<String, dynamic> json) =
       _$UserDetailedNotMeImpl.fromJson;
@@ -1598,6 +1696,11 @@ abstract class _UserDetailedNotMe implements UserDetailedNotMe {
   @NullableUriConverter()
   Uri? get uri;
   @override
+  @NullableUriConverter()
+  Uri? get movedTo;
+  @override
+  List<String>? get alsoKnownAs;
+  @override
   @DateTimeConverter()
   DateTime get createdAt;
   @override
@@ -1628,6 +1731,8 @@ abstract class _UserDetailedNotMe implements UserDetailedNotMe {
   String? get lang;
   @override
   List<UserField>? get fields;
+  @override
+  List<String> get verifiedLinks;
   @override
   int get followersCount;
   @override
@@ -1662,6 +1767,8 @@ abstract class _UserDetailedNotMe implements UserDetailedNotMe {
   @override
   String? get memo;
   @override
+  String? get moderationNote;
+  @override
   @JsonKey(ignore: true)
   _$$UserDetailedNotMeImplCopyWith<_$UserDetailedNotMeImpl> get copyWith =>
       throw _privateConstructorUsedError;
@@ -1695,6 +1802,9 @@ mixin _$UserDetailedNotMeWithRelations {
   Uri? get url => throw _privateConstructorUsedError;
   @NullableUriConverter()
   Uri? get uri => throw _privateConstructorUsedError;
+  @NullableUriConverter()
+  Uri? get movedTo => throw _privateConstructorUsedError;
+  List<String>? get alsoKnownAs => throw _privateConstructorUsedError;
   @DateTimeConverter()
   DateTime get createdAt => throw _privateConstructorUsedError;
   @NullableDateTimeConverter()
@@ -1713,6 +1823,7 @@ mixin _$UserDetailedNotMeWithRelations {
   DateTime? get birthday => throw _privateConstructorUsedError;
   String? get lang => throw _privateConstructorUsedError;
   List<UserField>? get fields => throw _privateConstructorUsedError;
+  List<String> get verifiedLinks => throw _privateConstructorUsedError;
   int get followersCount => throw _privateConstructorUsedError;
   int get followingCount => throw _privateConstructorUsedError;
   int get notesCount => throw _privateConstructorUsedError;
@@ -1730,6 +1841,7 @@ mixin _$UserDetailedNotMeWithRelations {
   bool get securityKeys => throw _privateConstructorUsedError;
   List<UserRole>? get roles => throw _privateConstructorUsedError;
   String? get memo => throw _privateConstructorUsedError;
+  String? get moderationNote => throw _privateConstructorUsedError;
   bool get isFollowing => throw _privateConstructorUsedError;
   bool get isFollowed => throw _privateConstructorUsedError;
   bool get hasPendingFollowRequestFromYou => throw _privateConstructorUsedError;
@@ -1738,6 +1850,8 @@ mixin _$UserDetailedNotMeWithRelations {
   bool get isBlocked => throw _privateConstructorUsedError;
   bool get isMuted => throw _privateConstructorUsedError;
   bool get isRenoteMuted => throw _privateConstructorUsedError;
+  Notify? get notify => throw _privateConstructorUsedError;
+  bool? get withReplies => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -1769,6 +1883,8 @@ abstract class $UserDetailedNotMeWithRelationsCopyWith<$Res> {
       List<UserBadgeRole> badgeRoles,
       @NullableUriConverter() Uri? url,
       @NullableUriConverter() Uri? uri,
+      @NullableUriConverter() Uri? movedTo,
+      List<String>? alsoKnownAs,
       @DateTimeConverter() DateTime createdAt,
       @NullableDateTimeConverter() DateTime? updatedAt,
       @NullableDateTimeConverter() DateTime? lastFetchedAt,
@@ -1782,6 +1898,7 @@ abstract class $UserDetailedNotMeWithRelationsCopyWith<$Res> {
       @NullableDateTimeConverter() DateTime? birthday,
       String? lang,
       List<UserField>? fields,
+      List<String> verifiedLinks,
       int followersCount,
       int followingCount,
       int notesCount,
@@ -1798,6 +1915,7 @@ abstract class $UserDetailedNotMeWithRelationsCopyWith<$Res> {
       bool securityKeys,
       List<UserRole>? roles,
       String? memo,
+      String? moderationNote,
       bool isFollowing,
       bool isFollowed,
       bool hasPendingFollowRequestFromYou,
@@ -1805,7 +1923,9 @@ abstract class $UserDetailedNotMeWithRelationsCopyWith<$Res> {
       bool isBlocking,
       bool isBlocked,
       bool isMuted,
-      bool isRenoteMuted});
+      bool isRenoteMuted,
+      Notify? notify,
+      bool? withReplies});
 
   $UserInstanceInfoCopyWith<$Res>? get instance;
 }
@@ -1839,6 +1959,8 @@ class _$UserDetailedNotMeWithRelationsCopyWithImpl<$Res,
     Object? badgeRoles = null,
     Object? url = freezed,
     Object? uri = freezed,
+    Object? movedTo = freezed,
+    Object? alsoKnownAs = freezed,
     Object? createdAt = null,
     Object? updatedAt = freezed,
     Object? lastFetchedAt = freezed,
@@ -1852,6 +1974,7 @@ class _$UserDetailedNotMeWithRelationsCopyWithImpl<$Res,
     Object? birthday = freezed,
     Object? lang = freezed,
     Object? fields = freezed,
+    Object? verifiedLinks = null,
     Object? followersCount = null,
     Object? followingCount = null,
     Object? notesCount = null,
@@ -1868,6 +1991,7 @@ class _$UserDetailedNotMeWithRelationsCopyWithImpl<$Res,
     Object? securityKeys = null,
     Object? roles = freezed,
     Object? memo = freezed,
+    Object? moderationNote = freezed,
     Object? isFollowing = null,
     Object? isFollowed = null,
     Object? hasPendingFollowRequestFromYou = null,
@@ -1876,6 +2000,8 @@ class _$UserDetailedNotMeWithRelationsCopyWithImpl<$Res,
     Object? isBlocked = null,
     Object? isMuted = null,
     Object? isRenoteMuted = null,
+    Object? notify = freezed,
+    Object? withReplies = freezed,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -1938,6 +2064,14 @@ class _$UserDetailedNotMeWithRelationsCopyWithImpl<$Res,
           ? _value.uri
           : uri // ignore: cast_nullable_to_non_nullable
               as Uri?,
+      movedTo: freezed == movedTo
+          ? _value.movedTo
+          : movedTo // ignore: cast_nullable_to_non_nullable
+              as Uri?,
+      alsoKnownAs: freezed == alsoKnownAs
+          ? _value.alsoKnownAs
+          : alsoKnownAs // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -1990,6 +2124,10 @@ class _$UserDetailedNotMeWithRelationsCopyWithImpl<$Res,
           ? _value.fields
           : fields // ignore: cast_nullable_to_non_nullable
               as List<UserField>?,
+      verifiedLinks: null == verifiedLinks
+          ? _value.verifiedLinks
+          : verifiedLinks // ignore: cast_nullable_to_non_nullable
+              as List<String>,
       followersCount: null == followersCount
           ? _value.followersCount
           : followersCount // ignore: cast_nullable_to_non_nullable
@@ -2054,6 +2192,10 @@ class _$UserDetailedNotMeWithRelationsCopyWithImpl<$Res,
           ? _value.memo
           : memo // ignore: cast_nullable_to_non_nullable
               as String?,
+      moderationNote: freezed == moderationNote
+          ? _value.moderationNote
+          : moderationNote // ignore: cast_nullable_to_non_nullable
+              as String?,
       isFollowing: null == isFollowing
           ? _value.isFollowing
           : isFollowing // ignore: cast_nullable_to_non_nullable
@@ -2086,6 +2228,14 @@ class _$UserDetailedNotMeWithRelationsCopyWithImpl<$Res,
           ? _value.isRenoteMuted
           : isRenoteMuted // ignore: cast_nullable_to_non_nullable
               as bool,
+      notify: freezed == notify
+          ? _value.notify
+          : notify // ignore: cast_nullable_to_non_nullable
+              as Notify?,
+      withReplies: freezed == withReplies
+          ? _value.withReplies
+          : withReplies // ignore: cast_nullable_to_non_nullable
+              as bool?,
     ) as $Val);
   }
 
@@ -2127,6 +2277,8 @@ abstract class _$$UserDetailedNotMeWithRelationsImplCopyWith<$Res>
       List<UserBadgeRole> badgeRoles,
       @NullableUriConverter() Uri? url,
       @NullableUriConverter() Uri? uri,
+      @NullableUriConverter() Uri? movedTo,
+      List<String>? alsoKnownAs,
       @DateTimeConverter() DateTime createdAt,
       @NullableDateTimeConverter() DateTime? updatedAt,
       @NullableDateTimeConverter() DateTime? lastFetchedAt,
@@ -2140,6 +2292,7 @@ abstract class _$$UserDetailedNotMeWithRelationsImplCopyWith<$Res>
       @NullableDateTimeConverter() DateTime? birthday,
       String? lang,
       List<UserField>? fields,
+      List<String> verifiedLinks,
       int followersCount,
       int followingCount,
       int notesCount,
@@ -2156,6 +2309,7 @@ abstract class _$$UserDetailedNotMeWithRelationsImplCopyWith<$Res>
       bool securityKeys,
       List<UserRole>? roles,
       String? memo,
+      String? moderationNote,
       bool isFollowing,
       bool isFollowed,
       bool hasPendingFollowRequestFromYou,
@@ -2163,7 +2317,9 @@ abstract class _$$UserDetailedNotMeWithRelationsImplCopyWith<$Res>
       bool isBlocking,
       bool isBlocked,
       bool isMuted,
-      bool isRenoteMuted});
+      bool isRenoteMuted,
+      Notify? notify,
+      bool? withReplies});
 
   @override
   $UserInstanceInfoCopyWith<$Res>? get instance;
@@ -2197,6 +2353,8 @@ class __$$UserDetailedNotMeWithRelationsImplCopyWithImpl<$Res>
     Object? badgeRoles = null,
     Object? url = freezed,
     Object? uri = freezed,
+    Object? movedTo = freezed,
+    Object? alsoKnownAs = freezed,
     Object? createdAt = null,
     Object? updatedAt = freezed,
     Object? lastFetchedAt = freezed,
@@ -2210,6 +2368,7 @@ class __$$UserDetailedNotMeWithRelationsImplCopyWithImpl<$Res>
     Object? birthday = freezed,
     Object? lang = freezed,
     Object? fields = freezed,
+    Object? verifiedLinks = null,
     Object? followersCount = null,
     Object? followingCount = null,
     Object? notesCount = null,
@@ -2226,6 +2385,7 @@ class __$$UserDetailedNotMeWithRelationsImplCopyWithImpl<$Res>
     Object? securityKeys = null,
     Object? roles = freezed,
     Object? memo = freezed,
+    Object? moderationNote = freezed,
     Object? isFollowing = null,
     Object? isFollowed = null,
     Object? hasPendingFollowRequestFromYou = null,
@@ -2234,6 +2394,8 @@ class __$$UserDetailedNotMeWithRelationsImplCopyWithImpl<$Res>
     Object? isBlocked = null,
     Object? isMuted = null,
     Object? isRenoteMuted = null,
+    Object? notify = freezed,
+    Object? withReplies = freezed,
   }) {
     return _then(_$UserDetailedNotMeWithRelationsImpl(
       id: null == id
@@ -2296,6 +2458,14 @@ class __$$UserDetailedNotMeWithRelationsImplCopyWithImpl<$Res>
           ? _value.uri
           : uri // ignore: cast_nullable_to_non_nullable
               as Uri?,
+      movedTo: freezed == movedTo
+          ? _value.movedTo
+          : movedTo // ignore: cast_nullable_to_non_nullable
+              as Uri?,
+      alsoKnownAs: freezed == alsoKnownAs
+          ? _value._alsoKnownAs
+          : alsoKnownAs // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -2348,6 +2518,10 @@ class __$$UserDetailedNotMeWithRelationsImplCopyWithImpl<$Res>
           ? _value._fields
           : fields // ignore: cast_nullable_to_non_nullable
               as List<UserField>?,
+      verifiedLinks: null == verifiedLinks
+          ? _value._verifiedLinks
+          : verifiedLinks // ignore: cast_nullable_to_non_nullable
+              as List<String>,
       followersCount: null == followersCount
           ? _value.followersCount
           : followersCount // ignore: cast_nullable_to_non_nullable
@@ -2412,6 +2586,10 @@ class __$$UserDetailedNotMeWithRelationsImplCopyWithImpl<$Res>
           ? _value.memo
           : memo // ignore: cast_nullable_to_non_nullable
               as String?,
+      moderationNote: freezed == moderationNote
+          ? _value.moderationNote
+          : moderationNote // ignore: cast_nullable_to_non_nullable
+              as String?,
       isFollowing: null == isFollowing
           ? _value.isFollowing
           : isFollowing // ignore: cast_nullable_to_non_nullable
@@ -2444,6 +2622,14 @@ class __$$UserDetailedNotMeWithRelationsImplCopyWithImpl<$Res>
           ? _value.isRenoteMuted
           : isRenoteMuted // ignore: cast_nullable_to_non_nullable
               as bool,
+      notify: freezed == notify
+          ? _value.notify
+          : notify // ignore: cast_nullable_to_non_nullable
+              as Notify?,
+      withReplies: freezed == withReplies
+          ? _value.withReplies
+          : withReplies // ignore: cast_nullable_to_non_nullable
+              as bool?,
     ));
   }
 }
@@ -2468,6 +2654,8 @@ class _$UserDetailedNotMeWithRelationsImpl
       final List<UserBadgeRole> badgeRoles = const [],
       @NullableUriConverter() this.url,
       @NullableUriConverter() this.uri,
+      @NullableUriConverter() this.movedTo,
+      final List<String>? alsoKnownAs,
       @DateTimeConverter() required this.createdAt,
       @NullableDateTimeConverter() this.updatedAt,
       @NullableDateTimeConverter() this.lastFetchedAt,
@@ -2481,6 +2669,7 @@ class _$UserDetailedNotMeWithRelationsImpl
       @NullableDateTimeConverter() this.birthday,
       this.lang,
       final List<UserField>? fields,
+      final List<String> verifiedLinks = const [],
       required this.followersCount,
       required this.followingCount,
       required this.notesCount,
@@ -2497,6 +2686,7 @@ class _$UserDetailedNotMeWithRelationsImpl
       required this.securityKeys,
       final List<UserRole>? roles,
       this.memo,
+      this.moderationNote,
       required this.isFollowing,
       required this.isFollowed,
       required this.hasPendingFollowRequestFromYou,
@@ -2504,11 +2694,15 @@ class _$UserDetailedNotMeWithRelationsImpl
       required this.isBlocking,
       required this.isBlocked,
       required this.isMuted,
-      required this.isRenoteMuted})
+      required this.isRenoteMuted,
+      this.notify,
+      this.withReplies})
       : _avatarDecorations = avatarDecorations,
         _emojis = emojis,
         _badgeRoles = badgeRoles,
+        _alsoKnownAs = alsoKnownAs,
         _fields = fields,
+        _verifiedLinks = verifiedLinks,
         _pinnedNoteIds = pinnedNoteIds,
         _pinnedNotes = pinnedNotes,
         _pinnedPage = pinnedPage,
@@ -2576,6 +2770,19 @@ class _$UserDetailedNotMeWithRelationsImpl
   @NullableUriConverter()
   final Uri? uri;
   @override
+  @NullableUriConverter()
+  final Uri? movedTo;
+  final List<String>? _alsoKnownAs;
+  @override
+  List<String>? get alsoKnownAs {
+    final value = _alsoKnownAs;
+    if (value == null) return null;
+    if (_alsoKnownAs is EqualUnmodifiableListView) return _alsoKnownAs;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
   @DateTimeConverter()
   final DateTime createdAt;
   @override
@@ -2612,6 +2819,15 @@ class _$UserDetailedNotMeWithRelationsImpl
     if (_fields is EqualUnmodifiableListView) return _fields;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(value);
+  }
+
+  final List<String> _verifiedLinks;
+  @override
+  @JsonKey()
+  List<String> get verifiedLinks {
+    if (_verifiedLinks is EqualUnmodifiableListView) return _verifiedLinks;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_verifiedLinks);
   }
 
   @override
@@ -2680,6 +2896,8 @@ class _$UserDetailedNotMeWithRelationsImpl
   @override
   final String? memo;
   @override
+  final String? moderationNote;
+  @override
   final bool isFollowing;
   @override
   final bool isFollowed;
@@ -2695,10 +2913,14 @@ class _$UserDetailedNotMeWithRelationsImpl
   final bool isMuted;
   @override
   final bool isRenoteMuted;
+  @override
+  final Notify? notify;
+  @override
+  final bool? withReplies;
 
   @override
   String toString() {
-    return 'UserDetailedNotMeWithRelations(id: $id, name: $name, username: $username, host: $host, avatarUrl: $avatarUrl, avatarBlurhash: $avatarBlurhash, avatarDecorations: $avatarDecorations, isBot: $isBot, isCat: $isCat, instance: $instance, emojis: $emojis, onlineStatus: $onlineStatus, badgeRoles: $badgeRoles, url: $url, uri: $uri, createdAt: $createdAt, updatedAt: $updatedAt, lastFetchedAt: $lastFetchedAt, bannerUrl: $bannerUrl, bannerBlurhash: $bannerBlurhash, isLocked: $isLocked, isSilenced: $isSilenced, isSuspended: $isSuspended, description: $description, location: $location, birthday: $birthday, lang: $lang, fields: $fields, followersCount: $followersCount, followingCount: $followingCount, notesCount: $notesCount, pinnedNoteIds: $pinnedNoteIds, pinnedNotes: $pinnedNotes, pinnedPageId: $pinnedPageId, pinnedPage: $pinnedPage, publicReactions: $publicReactions, ffVisibility: $ffVisibility, followersVisibility: $followersVisibility, followingVisibility: $followingVisibility, twoFactorEnabled: $twoFactorEnabled, usePasswordLessLogin: $usePasswordLessLogin, securityKeys: $securityKeys, roles: $roles, memo: $memo, isFollowing: $isFollowing, isFollowed: $isFollowed, hasPendingFollowRequestFromYou: $hasPendingFollowRequestFromYou, hasPendingFollowRequestToYou: $hasPendingFollowRequestToYou, isBlocking: $isBlocking, isBlocked: $isBlocked, isMuted: $isMuted, isRenoteMuted: $isRenoteMuted)';
+    return 'UserDetailedNotMeWithRelations(id: $id, name: $name, username: $username, host: $host, avatarUrl: $avatarUrl, avatarBlurhash: $avatarBlurhash, avatarDecorations: $avatarDecorations, isBot: $isBot, isCat: $isCat, instance: $instance, emojis: $emojis, onlineStatus: $onlineStatus, badgeRoles: $badgeRoles, url: $url, uri: $uri, movedTo: $movedTo, alsoKnownAs: $alsoKnownAs, createdAt: $createdAt, updatedAt: $updatedAt, lastFetchedAt: $lastFetchedAt, bannerUrl: $bannerUrl, bannerBlurhash: $bannerBlurhash, isLocked: $isLocked, isSilenced: $isSilenced, isSuspended: $isSuspended, description: $description, location: $location, birthday: $birthday, lang: $lang, fields: $fields, verifiedLinks: $verifiedLinks, followersCount: $followersCount, followingCount: $followingCount, notesCount: $notesCount, pinnedNoteIds: $pinnedNoteIds, pinnedNotes: $pinnedNotes, pinnedPageId: $pinnedPageId, pinnedPage: $pinnedPage, publicReactions: $publicReactions, ffVisibility: $ffVisibility, followersVisibility: $followersVisibility, followingVisibility: $followingVisibility, twoFactorEnabled: $twoFactorEnabled, usePasswordLessLogin: $usePasswordLessLogin, securityKeys: $securityKeys, roles: $roles, memo: $memo, moderationNote: $moderationNote, isFollowing: $isFollowing, isFollowed: $isFollowed, hasPendingFollowRequestFromYou: $hasPendingFollowRequestFromYou, hasPendingFollowRequestToYou: $hasPendingFollowRequestToYou, isBlocking: $isBlocking, isBlocked: $isBlocked, isMuted: $isMuted, isRenoteMuted: $isRenoteMuted, notify: $notify, withReplies: $withReplies)';
   }
 
   @override
@@ -2728,6 +2950,9 @@ class _$UserDetailedNotMeWithRelationsImpl
                 .equals(other._badgeRoles, _badgeRoles) &&
             (identical(other.url, url) || other.url == url) &&
             (identical(other.uri, uri) || other.uri == uri) &&
+            (identical(other.movedTo, movedTo) || other.movedTo == movedTo) &&
+            const DeepCollectionEquality()
+                .equals(other._alsoKnownAs, _alsoKnownAs) &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             (identical(other.updatedAt, updatedAt) ||
@@ -2752,6 +2977,8 @@ class _$UserDetailedNotMeWithRelationsImpl
                 other.birthday == birthday) &&
             (identical(other.lang, lang) || other.lang == lang) &&
             const DeepCollectionEquality().equals(other._fields, _fields) &&
+            const DeepCollectionEquality()
+                .equals(other._verifiedLinks, _verifiedLinks) &&
             (identical(other.followersCount, followersCount) ||
                 other.followersCount == followersCount) &&
             (identical(other.followingCount, followingCount) ||
@@ -2782,6 +3009,8 @@ class _$UserDetailedNotMeWithRelationsImpl
                 other.securityKeys == securityKeys) &&
             const DeepCollectionEquality().equals(other._roles, _roles) &&
             (identical(other.memo, memo) || other.memo == memo) &&
+            (identical(other.moderationNote, moderationNote) ||
+                other.moderationNote == moderationNote) &&
             (identical(other.isFollowing, isFollowing) ||
                 other.isFollowing == isFollowing) &&
             (identical(other.isFollowed, isFollowed) ||
@@ -2797,8 +3026,9 @@ class _$UserDetailedNotMeWithRelationsImpl
             (identical(other.isBlocked, isBlocked) ||
                 other.isBlocked == isBlocked) &&
             (identical(other.isMuted, isMuted) || other.isMuted == isMuted) &&
-            (identical(other.isRenoteMuted, isRenoteMuted) ||
-                other.isRenoteMuted == isRenoteMuted));
+            (identical(other.isRenoteMuted, isRenoteMuted) || other.isRenoteMuted == isRenoteMuted) &&
+            (identical(other.notify, notify) || other.notify == notify) &&
+            (identical(other.withReplies, withReplies) || other.withReplies == withReplies));
   }
 
   @JsonKey(ignore: true)
@@ -2820,6 +3050,8 @@ class _$UserDetailedNotMeWithRelationsImpl
         const DeepCollectionEquality().hash(_badgeRoles),
         url,
         uri,
+        movedTo,
+        const DeepCollectionEquality().hash(_alsoKnownAs),
         createdAt,
         updatedAt,
         lastFetchedAt,
@@ -2833,6 +3065,7 @@ class _$UserDetailedNotMeWithRelationsImpl
         birthday,
         lang,
         const DeepCollectionEquality().hash(_fields),
+        const DeepCollectionEquality().hash(_verifiedLinks),
         followersCount,
         followingCount,
         notesCount,
@@ -2849,6 +3082,7 @@ class _$UserDetailedNotMeWithRelationsImpl
         securityKeys,
         const DeepCollectionEquality().hash(_roles),
         memo,
+        moderationNote,
         isFollowing,
         isFollowed,
         hasPendingFollowRequestFromYou,
@@ -2856,7 +3090,9 @@ class _$UserDetailedNotMeWithRelationsImpl
         isBlocking,
         isBlocked,
         isMuted,
-        isRenoteMuted
+        isRenoteMuted,
+        notify,
+        withReplies
       ]);
 
   @JsonKey(ignore: true)
@@ -2878,59 +3114,64 @@ class _$UserDetailedNotMeWithRelationsImpl
 abstract class _UserDetailedNotMeWithRelations
     implements UserDetailedNotMeWithRelations {
   const factory _UserDetailedNotMeWithRelations(
-          {required final String id,
-          final String? name,
-          required final String username,
-          final String? host,
-          @UriConverter() required final Uri avatarUrl,
-          final String? avatarBlurhash,
-          final List<UserAvatarDecoration> avatarDecorations,
-          required final bool isBot,
-          required final bool isCat,
-          final UserInstanceInfo? instance,
-          @EmojisConverter() final Map<String, String> emojis,
-          @OnlineStatusJsonConverter() final OnlineStatus? onlineStatus,
-          final List<UserBadgeRole> badgeRoles,
-          @NullableUriConverter() final Uri? url,
-          @NullableUriConverter() final Uri? uri,
-          @DateTimeConverter() required final DateTime createdAt,
-          @NullableDateTimeConverter() final DateTime? updatedAt,
-          @NullableDateTimeConverter() final DateTime? lastFetchedAt,
-          @NullableUriConverter() final Uri? bannerUrl,
-          final String? bannerBlurhash,
-          required final bool isLocked,
-          required final bool isSilenced,
-          required final bool isSuspended,
-          final String? description,
-          final String? location,
-          @NullableDateTimeConverter() final DateTime? birthday,
-          final String? lang,
-          final List<UserField>? fields,
-          required final int followersCount,
-          required final int followingCount,
-          required final int notesCount,
-          final List<String>? pinnedNoteIds,
-          final List<Note>? pinnedNotes,
-          final String? pinnedPageId,
-          final Map<String, dynamic>? pinnedPage,
-          required final bool publicReactions,
-          @Deprecated("removed at 2023.12.0") final FFVisibility? ffVisibility,
-          final FFVisibility? followersVisibility,
-          final FFVisibility? followingVisibility,
-          required final bool twoFactorEnabled,
-          required final bool usePasswordLessLogin,
-          required final bool securityKeys,
-          final List<UserRole>? roles,
-          final String? memo,
-          required final bool isFollowing,
-          required final bool isFollowed,
-          required final bool hasPendingFollowRequestFromYou,
-          required final bool hasPendingFollowRequestToYou,
-          required final bool isBlocking,
-          required final bool isBlocked,
-          required final bool isMuted,
-          required final bool isRenoteMuted}) =
-      _$UserDetailedNotMeWithRelationsImpl;
+      {required final String id,
+      final String? name,
+      required final String username,
+      final String? host,
+      @UriConverter() required final Uri avatarUrl,
+      final String? avatarBlurhash,
+      final List<UserAvatarDecoration> avatarDecorations,
+      required final bool isBot,
+      required final bool isCat,
+      final UserInstanceInfo? instance,
+      @EmojisConverter() final Map<String, String> emojis,
+      @OnlineStatusJsonConverter() final OnlineStatus? onlineStatus,
+      final List<UserBadgeRole> badgeRoles,
+      @NullableUriConverter() final Uri? url,
+      @NullableUriConverter() final Uri? uri,
+      @NullableUriConverter() final Uri? movedTo,
+      final List<String>? alsoKnownAs,
+      @DateTimeConverter() required final DateTime createdAt,
+      @NullableDateTimeConverter() final DateTime? updatedAt,
+      @NullableDateTimeConverter() final DateTime? lastFetchedAt,
+      @NullableUriConverter() final Uri? bannerUrl,
+      final String? bannerBlurhash,
+      required final bool isLocked,
+      required final bool isSilenced,
+      required final bool isSuspended,
+      final String? description,
+      final String? location,
+      @NullableDateTimeConverter() final DateTime? birthday,
+      final String? lang,
+      final List<UserField>? fields,
+      final List<String> verifiedLinks,
+      required final int followersCount,
+      required final int followingCount,
+      required final int notesCount,
+      final List<String>? pinnedNoteIds,
+      final List<Note>? pinnedNotes,
+      final String? pinnedPageId,
+      final Map<String, dynamic>? pinnedPage,
+      required final bool publicReactions,
+      @Deprecated("removed at 2023.12.0") final FFVisibility? ffVisibility,
+      final FFVisibility? followersVisibility,
+      final FFVisibility? followingVisibility,
+      required final bool twoFactorEnabled,
+      required final bool usePasswordLessLogin,
+      required final bool securityKeys,
+      final List<UserRole>? roles,
+      final String? memo,
+      final String? moderationNote,
+      required final bool isFollowing,
+      required final bool isFollowed,
+      required final bool hasPendingFollowRequestFromYou,
+      required final bool hasPendingFollowRequestToYou,
+      required final bool isBlocking,
+      required final bool isBlocked,
+      required final bool isMuted,
+      required final bool isRenoteMuted,
+      final Notify? notify,
+      final bool? withReplies}) = _$UserDetailedNotMeWithRelationsImpl;
 
   factory _UserDetailedNotMeWithRelations.fromJson(Map<String, dynamic> json) =
       _$UserDetailedNotMeWithRelationsImpl.fromJson;
@@ -2971,6 +3212,11 @@ abstract class _UserDetailedNotMeWithRelations
   @NullableUriConverter()
   Uri? get uri;
   @override
+  @NullableUriConverter()
+  Uri? get movedTo;
+  @override
+  List<String>? get alsoKnownAs;
+  @override
   @DateTimeConverter()
   DateTime get createdAt;
   @override
@@ -3001,6 +3247,8 @@ abstract class _UserDetailedNotMeWithRelations
   String? get lang;
   @override
   List<UserField>? get fields;
+  @override
+  List<String> get verifiedLinks;
   @override
   int get followersCount;
   @override
@@ -3035,6 +3283,8 @@ abstract class _UserDetailedNotMeWithRelations
   @override
   String? get memo;
   @override
+  String? get moderationNote;
+  @override
   bool get isFollowing;
   @override
   bool get isFollowed;
@@ -3050,6 +3300,10 @@ abstract class _UserDetailedNotMeWithRelations
   bool get isMuted;
   @override
   bool get isRenoteMuted;
+  @override
+  Notify? get notify;
+  @override
+  bool? get withReplies;
   @override
   @JsonKey(ignore: true)
   _$$UserDetailedNotMeWithRelationsImplCopyWith<
@@ -3084,6 +3338,9 @@ mixin _$MeDetailed {
   Uri? get url => throw _privateConstructorUsedError;
   @NullableUriConverter()
   Uri? get uri => throw _privateConstructorUsedError;
+  @NullableUriConverter()
+  Uri? get movedTo => throw _privateConstructorUsedError;
+  List<String>? get alsoKnownAs => throw _privateConstructorUsedError;
   @DateTimeConverter()
   DateTime get createdAt => throw _privateConstructorUsedError;
   @NullableDateTimeConverter()
@@ -3102,6 +3359,7 @@ mixin _$MeDetailed {
   DateTime? get birthday => throw _privateConstructorUsedError;
   String? get lang => throw _privateConstructorUsedError;
   List<UserField>? get fields => throw _privateConstructorUsedError;
+  List<String> get verifiedLinks => throw _privateConstructorUsedError;
   int get followersCount => throw _privateConstructorUsedError;
   int get followingCount => throw _privateConstructorUsedError;
   int get notesCount => throw _privateConstructorUsedError;
@@ -3119,6 +3377,7 @@ mixin _$MeDetailed {
   bool get securityKeys => throw _privateConstructorUsedError;
   List<UserRole>? get roles => throw _privateConstructorUsedError;
   String? get memo => throw _privateConstructorUsedError;
+  String? get moderationNote => throw _privateConstructorUsedError;
   String? get avatarId => throw _privateConstructorUsedError;
   String? get bannerId => throw _privateConstructorUsedError;
   bool get isModerator => throw _privateConstructorUsedError;
@@ -3129,9 +3388,12 @@ mixin _$MeDetailed {
   bool get autoSensitive => throw _privateConstructorUsedError;
   bool get carefulBot => throw _privateConstructorUsedError;
   bool get autoAcceptFollowed => throw _privateConstructorUsedError;
+  bool? get preventAiLearning => throw _privateConstructorUsedError;
   bool get noCrawle => throw _privateConstructorUsedError;
   bool get isExplorable => throw _privateConstructorUsedError;
   bool get isDeleted => throw _privateConstructorUsedError;
+  TwoFactorBackupCodesStock? get twoFactorBackupCodesStock =>
+      throw _privateConstructorUsedError;
   bool get hideOnlineStatus => throw _privateConstructorUsedError;
   bool get hasUnreadSpecifiedNotes => throw _privateConstructorUsedError;
   bool get hasUnreadMentions => throw _privateConstructorUsedError;
@@ -3152,7 +3414,8 @@ mixin _$MeDetailed {
   @Deprecated("Deprecated in Misskey 2023.9.2")
   List<String>? get mutingNotificationTypes =>
       throw _privateConstructorUsedError;
-  dynamic get notificationRecieveConfig => throw _privateConstructorUsedError;
+  NotificationRecieveConfigs get notificationRecieveConfig =>
+      throw _privateConstructorUsedError;
   List<String> get emailNotificationTypes => throw _privateConstructorUsedError;
   List<UserAchievement> get achievements => throw _privateConstructorUsedError;
   int get loggedInDays => throw _privateConstructorUsedError;
@@ -3186,6 +3449,8 @@ abstract class $MeDetailedCopyWith<$Res> {
       List<UserBadgeRole> badgeRoles,
       @NullableUriConverter() Uri? url,
       @NullableUriConverter() Uri? uri,
+      @NullableUriConverter() Uri? movedTo,
+      List<String>? alsoKnownAs,
       @DateTimeConverter() DateTime createdAt,
       @NullableDateTimeConverter() DateTime? updatedAt,
       @NullableDateTimeConverter() DateTime? lastFetchedAt,
@@ -3199,6 +3464,7 @@ abstract class $MeDetailedCopyWith<$Res> {
       @NullableDateTimeConverter() DateTime? birthday,
       String? lang,
       List<UserField>? fields,
+      List<String> verifiedLinks,
       int followersCount,
       int followingCount,
       int notesCount,
@@ -3215,6 +3481,7 @@ abstract class $MeDetailedCopyWith<$Res> {
       bool securityKeys,
       List<UserRole>? roles,
       String? memo,
+      String? moderationNote,
       String? avatarId,
       String? bannerId,
       bool isModerator,
@@ -3225,9 +3492,11 @@ abstract class $MeDetailedCopyWith<$Res> {
       bool autoSensitive,
       bool carefulBot,
       bool autoAcceptFollowed,
+      bool? preventAiLearning,
       bool noCrawle,
       bool isExplorable,
       bool isDeleted,
+      TwoFactorBackupCodesStock? twoFactorBackupCodesStock,
       bool hideOnlineStatus,
       bool hasUnreadSpecifiedNotes,
       bool hasUnreadMentions,
@@ -3243,13 +3512,14 @@ abstract class $MeDetailedCopyWith<$Res> {
       List<String> mutedInstances,
       @Deprecated("Deprecated in Misskey 2023.9.2")
       List<String>? mutingNotificationTypes,
-      dynamic notificationRecieveConfig,
+      NotificationRecieveConfigs notificationRecieveConfig,
       List<String> emailNotificationTypes,
       List<UserAchievement> achievements,
       int loggedInDays,
       UserPolicies policies});
 
   $UserInstanceInfoCopyWith<$Res>? get instance;
+  $NotificationRecieveConfigsCopyWith<$Res> get notificationRecieveConfig;
   $UserPoliciesCopyWith<$Res> get policies;
 }
 
@@ -3281,6 +3551,8 @@ class _$MeDetailedCopyWithImpl<$Res, $Val extends MeDetailed>
     Object? badgeRoles = null,
     Object? url = freezed,
     Object? uri = freezed,
+    Object? movedTo = freezed,
+    Object? alsoKnownAs = freezed,
     Object? createdAt = null,
     Object? updatedAt = freezed,
     Object? lastFetchedAt = freezed,
@@ -3294,6 +3566,7 @@ class _$MeDetailedCopyWithImpl<$Res, $Val extends MeDetailed>
     Object? birthday = freezed,
     Object? lang = freezed,
     Object? fields = freezed,
+    Object? verifiedLinks = null,
     Object? followersCount = null,
     Object? followingCount = null,
     Object? notesCount = null,
@@ -3310,6 +3583,7 @@ class _$MeDetailedCopyWithImpl<$Res, $Val extends MeDetailed>
     Object? securityKeys = null,
     Object? roles = freezed,
     Object? memo = freezed,
+    Object? moderationNote = freezed,
     Object? avatarId = freezed,
     Object? bannerId = freezed,
     Object? isModerator = null,
@@ -3320,9 +3594,11 @@ class _$MeDetailedCopyWithImpl<$Res, $Val extends MeDetailed>
     Object? autoSensitive = null,
     Object? carefulBot = null,
     Object? autoAcceptFollowed = null,
+    Object? preventAiLearning = freezed,
     Object? noCrawle = null,
     Object? isExplorable = null,
     Object? isDeleted = null,
+    Object? twoFactorBackupCodesStock = freezed,
     Object? hideOnlineStatus = null,
     Object? hasUnreadSpecifiedNotes = null,
     Object? hasUnreadMentions = null,
@@ -3337,7 +3613,7 @@ class _$MeDetailedCopyWithImpl<$Res, $Val extends MeDetailed>
     Object? hardMutedWords = null,
     Object? mutedInstances = null,
     Object? mutingNotificationTypes = freezed,
-    Object? notificationRecieveConfig = freezed,
+    Object? notificationRecieveConfig = null,
     Object? emailNotificationTypes = null,
     Object? achievements = null,
     Object? loggedInDays = null,
@@ -3404,6 +3680,14 @@ class _$MeDetailedCopyWithImpl<$Res, $Val extends MeDetailed>
           ? _value.uri
           : uri // ignore: cast_nullable_to_non_nullable
               as Uri?,
+      movedTo: freezed == movedTo
+          ? _value.movedTo
+          : movedTo // ignore: cast_nullable_to_non_nullable
+              as Uri?,
+      alsoKnownAs: freezed == alsoKnownAs
+          ? _value.alsoKnownAs
+          : alsoKnownAs // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -3456,6 +3740,10 @@ class _$MeDetailedCopyWithImpl<$Res, $Val extends MeDetailed>
           ? _value.fields
           : fields // ignore: cast_nullable_to_non_nullable
               as List<UserField>?,
+      verifiedLinks: null == verifiedLinks
+          ? _value.verifiedLinks
+          : verifiedLinks // ignore: cast_nullable_to_non_nullable
+              as List<String>,
       followersCount: null == followersCount
           ? _value.followersCount
           : followersCount // ignore: cast_nullable_to_non_nullable
@@ -3520,6 +3808,10 @@ class _$MeDetailedCopyWithImpl<$Res, $Val extends MeDetailed>
           ? _value.memo
           : memo // ignore: cast_nullable_to_non_nullable
               as String?,
+      moderationNote: freezed == moderationNote
+          ? _value.moderationNote
+          : moderationNote // ignore: cast_nullable_to_non_nullable
+              as String?,
       avatarId: freezed == avatarId
           ? _value.avatarId
           : avatarId // ignore: cast_nullable_to_non_nullable
@@ -3560,6 +3852,10 @@ class _$MeDetailedCopyWithImpl<$Res, $Val extends MeDetailed>
           ? _value.autoAcceptFollowed
           : autoAcceptFollowed // ignore: cast_nullable_to_non_nullable
               as bool,
+      preventAiLearning: freezed == preventAiLearning
+          ? _value.preventAiLearning
+          : preventAiLearning // ignore: cast_nullable_to_non_nullable
+              as bool?,
       noCrawle: null == noCrawle
           ? _value.noCrawle
           : noCrawle // ignore: cast_nullable_to_non_nullable
@@ -3572,6 +3868,10 @@ class _$MeDetailedCopyWithImpl<$Res, $Val extends MeDetailed>
           ? _value.isDeleted
           : isDeleted // ignore: cast_nullable_to_non_nullable
               as bool,
+      twoFactorBackupCodesStock: freezed == twoFactorBackupCodesStock
+          ? _value.twoFactorBackupCodesStock
+          : twoFactorBackupCodesStock // ignore: cast_nullable_to_non_nullable
+              as TwoFactorBackupCodesStock?,
       hideOnlineStatus: null == hideOnlineStatus
           ? _value.hideOnlineStatus
           : hideOnlineStatus // ignore: cast_nullable_to_non_nullable
@@ -3628,10 +3928,10 @@ class _$MeDetailedCopyWithImpl<$Res, $Val extends MeDetailed>
           ? _value.mutingNotificationTypes
           : mutingNotificationTypes // ignore: cast_nullable_to_non_nullable
               as List<String>?,
-      notificationRecieveConfig: freezed == notificationRecieveConfig
+      notificationRecieveConfig: null == notificationRecieveConfig
           ? _value.notificationRecieveConfig
           : notificationRecieveConfig // ignore: cast_nullable_to_non_nullable
-              as dynamic,
+              as NotificationRecieveConfigs,
       emailNotificationTypes: null == emailNotificationTypes
           ? _value.emailNotificationTypes
           : emailNotificationTypes // ignore: cast_nullable_to_non_nullable
@@ -3660,6 +3960,15 @@ class _$MeDetailedCopyWithImpl<$Res, $Val extends MeDetailed>
 
     return $UserInstanceInfoCopyWith<$Res>(_value.instance!, (value) {
       return _then(_value.copyWith(instance: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $NotificationRecieveConfigsCopyWith<$Res> get notificationRecieveConfig {
+    return $NotificationRecieveConfigsCopyWith<$Res>(
+        _value.notificationRecieveConfig, (value) {
+      return _then(_value.copyWith(notificationRecieveConfig: value) as $Val);
     });
   }
 
@@ -3696,6 +4005,8 @@ abstract class _$$MeDetailedImplCopyWith<$Res>
       List<UserBadgeRole> badgeRoles,
       @NullableUriConverter() Uri? url,
       @NullableUriConverter() Uri? uri,
+      @NullableUriConverter() Uri? movedTo,
+      List<String>? alsoKnownAs,
       @DateTimeConverter() DateTime createdAt,
       @NullableDateTimeConverter() DateTime? updatedAt,
       @NullableDateTimeConverter() DateTime? lastFetchedAt,
@@ -3709,6 +4020,7 @@ abstract class _$$MeDetailedImplCopyWith<$Res>
       @NullableDateTimeConverter() DateTime? birthday,
       String? lang,
       List<UserField>? fields,
+      List<String> verifiedLinks,
       int followersCount,
       int followingCount,
       int notesCount,
@@ -3725,6 +4037,7 @@ abstract class _$$MeDetailedImplCopyWith<$Res>
       bool securityKeys,
       List<UserRole>? roles,
       String? memo,
+      String? moderationNote,
       String? avatarId,
       String? bannerId,
       bool isModerator,
@@ -3735,9 +4048,11 @@ abstract class _$$MeDetailedImplCopyWith<$Res>
       bool autoSensitive,
       bool carefulBot,
       bool autoAcceptFollowed,
+      bool? preventAiLearning,
       bool noCrawle,
       bool isExplorable,
       bool isDeleted,
+      TwoFactorBackupCodesStock? twoFactorBackupCodesStock,
       bool hideOnlineStatus,
       bool hasUnreadSpecifiedNotes,
       bool hasUnreadMentions,
@@ -3753,7 +4068,7 @@ abstract class _$$MeDetailedImplCopyWith<$Res>
       List<String> mutedInstances,
       @Deprecated("Deprecated in Misskey 2023.9.2")
       List<String>? mutingNotificationTypes,
-      dynamic notificationRecieveConfig,
+      NotificationRecieveConfigs notificationRecieveConfig,
       List<String> emailNotificationTypes,
       List<UserAchievement> achievements,
       int loggedInDays,
@@ -3761,6 +4076,8 @@ abstract class _$$MeDetailedImplCopyWith<$Res>
 
   @override
   $UserInstanceInfoCopyWith<$Res>? get instance;
+  @override
+  $NotificationRecieveConfigsCopyWith<$Res> get notificationRecieveConfig;
   @override
   $UserPoliciesCopyWith<$Res> get policies;
 }
@@ -3791,6 +4108,8 @@ class __$$MeDetailedImplCopyWithImpl<$Res>
     Object? badgeRoles = null,
     Object? url = freezed,
     Object? uri = freezed,
+    Object? movedTo = freezed,
+    Object? alsoKnownAs = freezed,
     Object? createdAt = null,
     Object? updatedAt = freezed,
     Object? lastFetchedAt = freezed,
@@ -3804,6 +4123,7 @@ class __$$MeDetailedImplCopyWithImpl<$Res>
     Object? birthday = freezed,
     Object? lang = freezed,
     Object? fields = freezed,
+    Object? verifiedLinks = null,
     Object? followersCount = null,
     Object? followingCount = null,
     Object? notesCount = null,
@@ -3820,6 +4140,7 @@ class __$$MeDetailedImplCopyWithImpl<$Res>
     Object? securityKeys = null,
     Object? roles = freezed,
     Object? memo = freezed,
+    Object? moderationNote = freezed,
     Object? avatarId = freezed,
     Object? bannerId = freezed,
     Object? isModerator = null,
@@ -3830,9 +4151,11 @@ class __$$MeDetailedImplCopyWithImpl<$Res>
     Object? autoSensitive = null,
     Object? carefulBot = null,
     Object? autoAcceptFollowed = null,
+    Object? preventAiLearning = freezed,
     Object? noCrawle = null,
     Object? isExplorable = null,
     Object? isDeleted = null,
+    Object? twoFactorBackupCodesStock = freezed,
     Object? hideOnlineStatus = null,
     Object? hasUnreadSpecifiedNotes = null,
     Object? hasUnreadMentions = null,
@@ -3847,7 +4170,7 @@ class __$$MeDetailedImplCopyWithImpl<$Res>
     Object? hardMutedWords = null,
     Object? mutedInstances = null,
     Object? mutingNotificationTypes = freezed,
-    Object? notificationRecieveConfig = freezed,
+    Object? notificationRecieveConfig = null,
     Object? emailNotificationTypes = null,
     Object? achievements = null,
     Object? loggedInDays = null,
@@ -3914,6 +4237,14 @@ class __$$MeDetailedImplCopyWithImpl<$Res>
           ? _value.uri
           : uri // ignore: cast_nullable_to_non_nullable
               as Uri?,
+      movedTo: freezed == movedTo
+          ? _value.movedTo
+          : movedTo // ignore: cast_nullable_to_non_nullable
+              as Uri?,
+      alsoKnownAs: freezed == alsoKnownAs
+          ? _value._alsoKnownAs
+          : alsoKnownAs // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -3966,6 +4297,10 @@ class __$$MeDetailedImplCopyWithImpl<$Res>
           ? _value._fields
           : fields // ignore: cast_nullable_to_non_nullable
               as List<UserField>?,
+      verifiedLinks: null == verifiedLinks
+          ? _value._verifiedLinks
+          : verifiedLinks // ignore: cast_nullable_to_non_nullable
+              as List<String>,
       followersCount: null == followersCount
           ? _value.followersCount
           : followersCount // ignore: cast_nullable_to_non_nullable
@@ -4030,6 +4365,10 @@ class __$$MeDetailedImplCopyWithImpl<$Res>
           ? _value.memo
           : memo // ignore: cast_nullable_to_non_nullable
               as String?,
+      moderationNote: freezed == moderationNote
+          ? _value.moderationNote
+          : moderationNote // ignore: cast_nullable_to_non_nullable
+              as String?,
       avatarId: freezed == avatarId
           ? _value.avatarId
           : avatarId // ignore: cast_nullable_to_non_nullable
@@ -4070,6 +4409,10 @@ class __$$MeDetailedImplCopyWithImpl<$Res>
           ? _value.autoAcceptFollowed
           : autoAcceptFollowed // ignore: cast_nullable_to_non_nullable
               as bool,
+      preventAiLearning: freezed == preventAiLearning
+          ? _value.preventAiLearning
+          : preventAiLearning // ignore: cast_nullable_to_non_nullable
+              as bool?,
       noCrawle: null == noCrawle
           ? _value.noCrawle
           : noCrawle // ignore: cast_nullable_to_non_nullable
@@ -4082,6 +4425,10 @@ class __$$MeDetailedImplCopyWithImpl<$Res>
           ? _value.isDeleted
           : isDeleted // ignore: cast_nullable_to_non_nullable
               as bool,
+      twoFactorBackupCodesStock: freezed == twoFactorBackupCodesStock
+          ? _value.twoFactorBackupCodesStock
+          : twoFactorBackupCodesStock // ignore: cast_nullable_to_non_nullable
+              as TwoFactorBackupCodesStock?,
       hideOnlineStatus: null == hideOnlineStatus
           ? _value.hideOnlineStatus
           : hideOnlineStatus // ignore: cast_nullable_to_non_nullable
@@ -4138,10 +4485,10 @@ class __$$MeDetailedImplCopyWithImpl<$Res>
           ? _value._mutingNotificationTypes
           : mutingNotificationTypes // ignore: cast_nullable_to_non_nullable
               as List<String>?,
-      notificationRecieveConfig: freezed == notificationRecieveConfig
+      notificationRecieveConfig: null == notificationRecieveConfig
           ? _value.notificationRecieveConfig
           : notificationRecieveConfig // ignore: cast_nullable_to_non_nullable
-              as dynamic,
+              as NotificationRecieveConfigs,
       emailNotificationTypes: null == emailNotificationTypes
           ? _value._emailNotificationTypes
           : emailNotificationTypes // ignore: cast_nullable_to_non_nullable
@@ -4181,6 +4528,8 @@ class _$MeDetailedImpl implements _MeDetailed {
       final List<UserBadgeRole> badgeRoles = const [],
       @NullableUriConverter() this.url,
       @NullableUriConverter() this.uri,
+      @NullableUriConverter() this.movedTo,
+      final List<String>? alsoKnownAs,
       @DateTimeConverter() required this.createdAt,
       @NullableDateTimeConverter() this.updatedAt,
       @NullableDateTimeConverter() this.lastFetchedAt,
@@ -4194,6 +4543,7 @@ class _$MeDetailedImpl implements _MeDetailed {
       @NullableDateTimeConverter() this.birthday,
       this.lang,
       final List<UserField>? fields,
+      final List<String> verifiedLinks = const [],
       required this.followersCount,
       required this.followingCount,
       required this.notesCount,
@@ -4210,6 +4560,7 @@ class _$MeDetailedImpl implements _MeDetailed {
       required this.securityKeys,
       final List<UserRole>? roles,
       this.memo,
+      this.moderationNote,
       this.avatarId,
       this.bannerId,
       required this.isModerator,
@@ -4220,9 +4571,11 @@ class _$MeDetailedImpl implements _MeDetailed {
       required this.autoSensitive,
       required this.carefulBot,
       required this.autoAcceptFollowed,
+      this.preventAiLearning,
       required this.noCrawle,
       required this.isExplorable,
       required this.isDeleted,
+      this.twoFactorBackupCodesStock,
       required this.hideOnlineStatus,
       required this.hasUnreadSpecifiedNotes,
       required this.hasUnreadMentions,
@@ -4238,7 +4591,7 @@ class _$MeDetailedImpl implements _MeDetailed {
       required final List<String> mutedInstances,
       @Deprecated("Deprecated in Misskey 2023.9.2")
       final List<String>? mutingNotificationTypes,
-      this.notificationRecieveConfig,
+      this.notificationRecieveConfig = const NotificationRecieveConfigs(),
       required final List<String> emailNotificationTypes,
       required final List<UserAchievement> achievements,
       required this.loggedInDays,
@@ -4246,7 +4599,9 @@ class _$MeDetailedImpl implements _MeDetailed {
       : _avatarDecorations = avatarDecorations,
         _emojis = emojis,
         _badgeRoles = badgeRoles,
+        _alsoKnownAs = alsoKnownAs,
         _fields = fields,
+        _verifiedLinks = verifiedLinks,
         _pinnedNoteIds = pinnedNoteIds,
         _pinnedNotes = pinnedNotes,
         _pinnedPage = pinnedPage,
@@ -4320,6 +4675,19 @@ class _$MeDetailedImpl implements _MeDetailed {
   @NullableUriConverter()
   final Uri? uri;
   @override
+  @NullableUriConverter()
+  final Uri? movedTo;
+  final List<String>? _alsoKnownAs;
+  @override
+  List<String>? get alsoKnownAs {
+    final value = _alsoKnownAs;
+    if (value == null) return null;
+    if (_alsoKnownAs is EqualUnmodifiableListView) return _alsoKnownAs;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
   @DateTimeConverter()
   final DateTime createdAt;
   @override
@@ -4356,6 +4724,15 @@ class _$MeDetailedImpl implements _MeDetailed {
     if (_fields is EqualUnmodifiableListView) return _fields;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(value);
+  }
+
+  final List<String> _verifiedLinks;
+  @override
+  @JsonKey()
+  List<String> get verifiedLinks {
+    if (_verifiedLinks is EqualUnmodifiableListView) return _verifiedLinks;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_verifiedLinks);
   }
 
   @override
@@ -4424,6 +4801,8 @@ class _$MeDetailedImpl implements _MeDetailed {
   @override
   final String? memo;
   @override
+  final String? moderationNote;
+  @override
   final String? avatarId;
   @override
   final String? bannerId;
@@ -4444,11 +4823,15 @@ class _$MeDetailedImpl implements _MeDetailed {
   @override
   final bool autoAcceptFollowed;
   @override
+  final bool? preventAiLearning;
+  @override
   final bool noCrawle;
   @override
   final bool isExplorable;
   @override
   final bool isDeleted;
+  @override
+  final TwoFactorBackupCodesStock? twoFactorBackupCodesStock;
   @override
   final bool hideOnlineStatus;
   @override
@@ -4517,7 +4900,8 @@ class _$MeDetailedImpl implements _MeDetailed {
   }
 
   @override
-  final dynamic notificationRecieveConfig;
+  @JsonKey()
+  final NotificationRecieveConfigs notificationRecieveConfig;
   final List<String> _emailNotificationTypes;
   @override
   List<String> get emailNotificationTypes {
@@ -4542,7 +4926,7 @@ class _$MeDetailedImpl implements _MeDetailed {
 
   @override
   String toString() {
-    return 'MeDetailed(id: $id, name: $name, username: $username, host: $host, avatarUrl: $avatarUrl, avatarBlurhash: $avatarBlurhash, avatarDecorations: $avatarDecorations, isBot: $isBot, isCat: $isCat, instance: $instance, emojis: $emojis, onlineStatus: $onlineStatus, badgeRoles: $badgeRoles, url: $url, uri: $uri, createdAt: $createdAt, updatedAt: $updatedAt, lastFetchedAt: $lastFetchedAt, bannerUrl: $bannerUrl, bannerBlurhash: $bannerBlurhash, isLocked: $isLocked, isSilenced: $isSilenced, isSuspended: $isSuspended, description: $description, location: $location, birthday: $birthday, lang: $lang, fields: $fields, followersCount: $followersCount, followingCount: $followingCount, notesCount: $notesCount, pinnedNoteIds: $pinnedNoteIds, pinnedNotes: $pinnedNotes, pinnedPageId: $pinnedPageId, pinnedPage: $pinnedPage, publicReactions: $publicReactions, ffVisibility: $ffVisibility, followersVisibility: $followersVisibility, followingVisibility: $followingVisibility, twoFactorEnabled: $twoFactorEnabled, usePasswordLessLogin: $usePasswordLessLogin, securityKeys: $securityKeys, roles: $roles, memo: $memo, avatarId: $avatarId, bannerId: $bannerId, isModerator: $isModerator, isAdmin: $isAdmin, injectFeaturedNote: $injectFeaturedNote, receiveAnnouncementEmail: $receiveAnnouncementEmail, alwaysMarkNsfw: $alwaysMarkNsfw, autoSensitive: $autoSensitive, carefulBot: $carefulBot, autoAcceptFollowed: $autoAcceptFollowed, noCrawle: $noCrawle, isExplorable: $isExplorable, isDeleted: $isDeleted, hideOnlineStatus: $hideOnlineStatus, hasUnreadSpecifiedNotes: $hasUnreadSpecifiedNotes, hasUnreadMentions: $hasUnreadMentions, hasUnreadAnnouncement: $hasUnreadAnnouncement, hasUnreadAntenna: $hasUnreadAntenna, hasUnreadChannel: $hasUnreadChannel, hasUnreadNotification: $hasUnreadNotification, hasPendingReceivedFollowRequest: $hasPendingReceivedFollowRequest, unreadNotificationsCount: $unreadNotificationsCount, unreadAnnouncements: $unreadAnnouncements, mutedWords: $mutedWords, hardMutedWords: $hardMutedWords, mutedInstances: $mutedInstances, mutingNotificationTypes: $mutingNotificationTypes, notificationRecieveConfig: $notificationRecieveConfig, emailNotificationTypes: $emailNotificationTypes, achievements: $achievements, loggedInDays: $loggedInDays, policies: $policies)';
+    return 'MeDetailed(id: $id, name: $name, username: $username, host: $host, avatarUrl: $avatarUrl, avatarBlurhash: $avatarBlurhash, avatarDecorations: $avatarDecorations, isBot: $isBot, isCat: $isCat, instance: $instance, emojis: $emojis, onlineStatus: $onlineStatus, badgeRoles: $badgeRoles, url: $url, uri: $uri, movedTo: $movedTo, alsoKnownAs: $alsoKnownAs, createdAt: $createdAt, updatedAt: $updatedAt, lastFetchedAt: $lastFetchedAt, bannerUrl: $bannerUrl, bannerBlurhash: $bannerBlurhash, isLocked: $isLocked, isSilenced: $isSilenced, isSuspended: $isSuspended, description: $description, location: $location, birthday: $birthday, lang: $lang, fields: $fields, verifiedLinks: $verifiedLinks, followersCount: $followersCount, followingCount: $followingCount, notesCount: $notesCount, pinnedNoteIds: $pinnedNoteIds, pinnedNotes: $pinnedNotes, pinnedPageId: $pinnedPageId, pinnedPage: $pinnedPage, publicReactions: $publicReactions, ffVisibility: $ffVisibility, followersVisibility: $followersVisibility, followingVisibility: $followingVisibility, twoFactorEnabled: $twoFactorEnabled, usePasswordLessLogin: $usePasswordLessLogin, securityKeys: $securityKeys, roles: $roles, memo: $memo, moderationNote: $moderationNote, avatarId: $avatarId, bannerId: $bannerId, isModerator: $isModerator, isAdmin: $isAdmin, injectFeaturedNote: $injectFeaturedNote, receiveAnnouncementEmail: $receiveAnnouncementEmail, alwaysMarkNsfw: $alwaysMarkNsfw, autoSensitive: $autoSensitive, carefulBot: $carefulBot, autoAcceptFollowed: $autoAcceptFollowed, preventAiLearning: $preventAiLearning, noCrawle: $noCrawle, isExplorable: $isExplorable, isDeleted: $isDeleted, twoFactorBackupCodesStock: $twoFactorBackupCodesStock, hideOnlineStatus: $hideOnlineStatus, hasUnreadSpecifiedNotes: $hasUnreadSpecifiedNotes, hasUnreadMentions: $hasUnreadMentions, hasUnreadAnnouncement: $hasUnreadAnnouncement, hasUnreadAntenna: $hasUnreadAntenna, hasUnreadChannel: $hasUnreadChannel, hasUnreadNotification: $hasUnreadNotification, hasPendingReceivedFollowRequest: $hasPendingReceivedFollowRequest, unreadNotificationsCount: $unreadNotificationsCount, unreadAnnouncements: $unreadAnnouncements, mutedWords: $mutedWords, hardMutedWords: $hardMutedWords, mutedInstances: $mutedInstances, mutingNotificationTypes: $mutingNotificationTypes, notificationRecieveConfig: $notificationRecieveConfig, emailNotificationTypes: $emailNotificationTypes, achievements: $achievements, loggedInDays: $loggedInDays, policies: $policies)';
   }
 
   @override
@@ -4572,6 +4956,9 @@ class _$MeDetailedImpl implements _MeDetailed {
                 .equals(other._badgeRoles, _badgeRoles) &&
             (identical(other.url, url) || other.url == url) &&
             (identical(other.uri, uri) || other.uri == uri) &&
+            (identical(other.movedTo, movedTo) || other.movedTo == movedTo) &&
+            const DeepCollectionEquality()
+                .equals(other._alsoKnownAs, _alsoKnownAs) &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             (identical(other.updatedAt, updatedAt) ||
@@ -4596,6 +4983,8 @@ class _$MeDetailedImpl implements _MeDetailed {
                 other.birthday == birthday) &&
             (identical(other.lang, lang) || other.lang == lang) &&
             const DeepCollectionEquality().equals(other._fields, _fields) &&
+            const DeepCollectionEquality()
+                .equals(other._verifiedLinks, _verifiedLinks) &&
             (identical(other.followersCount, followersCount) ||
                 other.followersCount == followersCount) &&
             (identical(other.followingCount, followingCount) ||
@@ -4626,6 +5015,8 @@ class _$MeDetailedImpl implements _MeDetailed {
                 other.securityKeys == securityKeys) &&
             const DeepCollectionEquality().equals(other._roles, _roles) &&
             (identical(other.memo, memo) || other.memo == memo) &&
+            (identical(other.moderationNote, moderationNote) ||
+                other.moderationNote == moderationNote) &&
             (identical(other.avatarId, avatarId) ||
                 other.avatarId == avatarId) &&
             (identical(other.bannerId, bannerId) ||
@@ -4635,8 +5026,7 @@ class _$MeDetailedImpl implements _MeDetailed {
             (identical(other.isAdmin, isAdmin) || other.isAdmin == isAdmin) &&
             (identical(other.injectFeaturedNote, injectFeaturedNote) ||
                 other.injectFeaturedNote == injectFeaturedNote) &&
-            (identical(
-                    other.receiveAnnouncementEmail, receiveAnnouncementEmail) ||
+            (identical(other.receiveAnnouncementEmail, receiveAnnouncementEmail) ||
                 other.receiveAnnouncementEmail == receiveAnnouncementEmail) &&
             (identical(other.alwaysMarkNsfw, alwaysMarkNsfw) ||
                 other.alwaysMarkNsfw == alwaysMarkNsfw) &&
@@ -4644,11 +5034,12 @@ class _$MeDetailedImpl implements _MeDetailed {
                 other.autoSensitive == autoSensitive) &&
             (identical(other.carefulBot, carefulBot) ||
                 other.carefulBot == carefulBot) &&
-            (identical(other.autoAcceptFollowed, autoAcceptFollowed) ||
-                other.autoAcceptFollowed == autoAcceptFollowed) &&
+            (identical(other.autoAcceptFollowed, autoAcceptFollowed) || other.autoAcceptFollowed == autoAcceptFollowed) &&
+            (identical(other.preventAiLearning, preventAiLearning) || other.preventAiLearning == preventAiLearning) &&
             (identical(other.noCrawle, noCrawle) || other.noCrawle == noCrawle) &&
             (identical(other.isExplorable, isExplorable) || other.isExplorable == isExplorable) &&
             (identical(other.isDeleted, isDeleted) || other.isDeleted == isDeleted) &&
+            (identical(other.twoFactorBackupCodesStock, twoFactorBackupCodesStock) || other.twoFactorBackupCodesStock == twoFactorBackupCodesStock) &&
             (identical(other.hideOnlineStatus, hideOnlineStatus) || other.hideOnlineStatus == hideOnlineStatus) &&
             (identical(other.hasUnreadSpecifiedNotes, hasUnreadSpecifiedNotes) || other.hasUnreadSpecifiedNotes == hasUnreadSpecifiedNotes) &&
             (identical(other.hasUnreadMentions, hasUnreadMentions) || other.hasUnreadMentions == hasUnreadMentions) &&
@@ -4663,7 +5054,7 @@ class _$MeDetailedImpl implements _MeDetailed {
             const DeepCollectionEquality().equals(other._hardMutedWords, _hardMutedWords) &&
             const DeepCollectionEquality().equals(other._mutedInstances, _mutedInstances) &&
             const DeepCollectionEquality().equals(other._mutingNotificationTypes, _mutingNotificationTypes) &&
-            const DeepCollectionEquality().equals(other.notificationRecieveConfig, notificationRecieveConfig) &&
+            (identical(other.notificationRecieveConfig, notificationRecieveConfig) || other.notificationRecieveConfig == notificationRecieveConfig) &&
             const DeepCollectionEquality().equals(other._emailNotificationTypes, _emailNotificationTypes) &&
             const DeepCollectionEquality().equals(other._achievements, _achievements) &&
             (identical(other.loggedInDays, loggedInDays) || other.loggedInDays == loggedInDays) &&
@@ -4689,6 +5080,8 @@ class _$MeDetailedImpl implements _MeDetailed {
         const DeepCollectionEquality().hash(_badgeRoles),
         url,
         uri,
+        movedTo,
+        const DeepCollectionEquality().hash(_alsoKnownAs),
         createdAt,
         updatedAt,
         lastFetchedAt,
@@ -4702,6 +5095,7 @@ class _$MeDetailedImpl implements _MeDetailed {
         birthday,
         lang,
         const DeepCollectionEquality().hash(_fields),
+        const DeepCollectionEquality().hash(_verifiedLinks),
         followersCount,
         followingCount,
         notesCount,
@@ -4718,6 +5112,7 @@ class _$MeDetailedImpl implements _MeDetailed {
         securityKeys,
         const DeepCollectionEquality().hash(_roles),
         memo,
+        moderationNote,
         avatarId,
         bannerId,
         isModerator,
@@ -4728,9 +5123,11 @@ class _$MeDetailedImpl implements _MeDetailed {
         autoSensitive,
         carefulBot,
         autoAcceptFollowed,
+        preventAiLearning,
         noCrawle,
         isExplorable,
         isDeleted,
+        twoFactorBackupCodesStock,
         hideOnlineStatus,
         hasUnreadSpecifiedNotes,
         hasUnreadMentions,
@@ -4745,7 +5142,7 @@ class _$MeDetailedImpl implements _MeDetailed {
         const DeepCollectionEquality().hash(_hardMutedWords),
         const DeepCollectionEquality().hash(_mutedInstances),
         const DeepCollectionEquality().hash(_mutingNotificationTypes),
-        const DeepCollectionEquality().hash(notificationRecieveConfig),
+        notificationRecieveConfig,
         const DeepCollectionEquality().hash(_emailNotificationTypes),
         const DeepCollectionEquality().hash(_achievements),
         loggedInDays,
@@ -4783,6 +5180,8 @@ abstract class _MeDetailed implements MeDetailed {
       final List<UserBadgeRole> badgeRoles,
       @NullableUriConverter() final Uri? url,
       @NullableUriConverter() final Uri? uri,
+      @NullableUriConverter() final Uri? movedTo,
+      final List<String>? alsoKnownAs,
       @DateTimeConverter() required final DateTime createdAt,
       @NullableDateTimeConverter() final DateTime? updatedAt,
       @NullableDateTimeConverter() final DateTime? lastFetchedAt,
@@ -4796,6 +5195,7 @@ abstract class _MeDetailed implements MeDetailed {
       @NullableDateTimeConverter() final DateTime? birthday,
       final String? lang,
       final List<UserField>? fields,
+      final List<String> verifiedLinks,
       required final int followersCount,
       required final int followingCount,
       required final int notesCount,
@@ -4812,6 +5212,7 @@ abstract class _MeDetailed implements MeDetailed {
       required final bool securityKeys,
       final List<UserRole>? roles,
       final String? memo,
+      final String? moderationNote,
       final String? avatarId,
       final String? bannerId,
       required final bool isModerator,
@@ -4822,9 +5223,11 @@ abstract class _MeDetailed implements MeDetailed {
       required final bool autoSensitive,
       required final bool carefulBot,
       required final bool autoAcceptFollowed,
+      final bool? preventAiLearning,
       required final bool noCrawle,
       required final bool isExplorable,
       required final bool isDeleted,
+      final TwoFactorBackupCodesStock? twoFactorBackupCodesStock,
       required final bool hideOnlineStatus,
       required final bool hasUnreadSpecifiedNotes,
       required final bool hasUnreadMentions,
@@ -4840,7 +5243,7 @@ abstract class _MeDetailed implements MeDetailed {
       required final List<String> mutedInstances,
       @Deprecated("Deprecated in Misskey 2023.9.2")
       final List<String>? mutingNotificationTypes,
-      final dynamic notificationRecieveConfig,
+      final NotificationRecieveConfigs notificationRecieveConfig,
       required final List<String> emailNotificationTypes,
       required final List<UserAchievement> achievements,
       required final int loggedInDays,
@@ -4885,6 +5288,11 @@ abstract class _MeDetailed implements MeDetailed {
   @NullableUriConverter()
   Uri? get uri;
   @override
+  @NullableUriConverter()
+  Uri? get movedTo;
+  @override
+  List<String>? get alsoKnownAs;
+  @override
   @DateTimeConverter()
   DateTime get createdAt;
   @override
@@ -4915,6 +5323,8 @@ abstract class _MeDetailed implements MeDetailed {
   String? get lang;
   @override
   List<UserField>? get fields;
+  @override
+  List<String> get verifiedLinks;
   @override
   int get followersCount;
   @override
@@ -4949,6 +5359,8 @@ abstract class _MeDetailed implements MeDetailed {
   @override
   String? get memo;
   @override
+  String? get moderationNote;
+  @override
   String? get avatarId;
   @override
   String? get bannerId;
@@ -4969,11 +5381,15 @@ abstract class _MeDetailed implements MeDetailed {
   @override
   bool get autoAcceptFollowed;
   @override
+  bool? get preventAiLearning;
+  @override
   bool get noCrawle;
   @override
   bool get isExplorable;
   @override
   bool get isDeleted;
+  @override
+  TwoFactorBackupCodesStock? get twoFactorBackupCodesStock;
   @override
   bool get hideOnlineStatus;
   @override
@@ -5006,7 +5422,7 @@ abstract class _MeDetailed implements MeDetailed {
   @Deprecated("Deprecated in Misskey 2023.9.2")
   List<String>? get mutingNotificationTypes;
   @override
-  dynamic get notificationRecieveConfig;
+  NotificationRecieveConfigs get notificationRecieveConfig;
   @override
   List<String> get emailNotificationTypes;
   @override
@@ -6872,4 +7288,817 @@ abstract class _UserField implements UserField {
   @JsonKey(ignore: true)
   _$$UserFieldImplCopyWith<_$UserFieldImpl> get copyWith =>
       throw _privateConstructorUsedError;
+}
+
+NotificationRecieveConfigs _$NotificationRecieveConfigsFromJson(
+    Map<String, dynamic> json) {
+  return _NotificationRecieveConfigs.fromJson(json);
+}
+
+/// @nodoc
+mixin _$NotificationRecieveConfigs {
+  NotificationRecieveConfig? get note => throw _privateConstructorUsedError;
+  NotificationRecieveConfig? get follow => throw _privateConstructorUsedError;
+  NotificationRecieveConfig? get mention => throw _privateConstructorUsedError;
+  NotificationRecieveConfig? get reply => throw _privateConstructorUsedError;
+  NotificationRecieveConfig? get renote => throw _privateConstructorUsedError;
+  NotificationRecieveConfig? get quote => throw _privateConstructorUsedError;
+  NotificationRecieveConfig? get reaction => throw _privateConstructorUsedError;
+  NotificationRecieveConfig? get pollEnded =>
+      throw _privateConstructorUsedError;
+  NotificationRecieveConfig? get receiveFollowRequest =>
+      throw _privateConstructorUsedError;
+  NotificationRecieveConfig? get followRequestAccepted =>
+      throw _privateConstructorUsedError;
+  NotificationRecieveConfig? get roleAssigned =>
+      throw _privateConstructorUsedError;
+  NotificationRecieveConfig? get achievementEarned =>
+      throw _privateConstructorUsedError;
+  NotificationRecieveConfig? get app => throw _privateConstructorUsedError;
+  NotificationRecieveConfig? get test => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $NotificationRecieveConfigsCopyWith<NotificationRecieveConfigs>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $NotificationRecieveConfigsCopyWith<$Res> {
+  factory $NotificationRecieveConfigsCopyWith(NotificationRecieveConfigs value,
+          $Res Function(NotificationRecieveConfigs) then) =
+      _$NotificationRecieveConfigsCopyWithImpl<$Res,
+          NotificationRecieveConfigs>;
+  @useResult
+  $Res call(
+      {NotificationRecieveConfig? note,
+      NotificationRecieveConfig? follow,
+      NotificationRecieveConfig? mention,
+      NotificationRecieveConfig? reply,
+      NotificationRecieveConfig? renote,
+      NotificationRecieveConfig? quote,
+      NotificationRecieveConfig? reaction,
+      NotificationRecieveConfig? pollEnded,
+      NotificationRecieveConfig? receiveFollowRequest,
+      NotificationRecieveConfig? followRequestAccepted,
+      NotificationRecieveConfig? roleAssigned,
+      NotificationRecieveConfig? achievementEarned,
+      NotificationRecieveConfig? app,
+      NotificationRecieveConfig? test});
+
+  $NotificationRecieveConfigCopyWith<$Res>? get note;
+  $NotificationRecieveConfigCopyWith<$Res>? get follow;
+  $NotificationRecieveConfigCopyWith<$Res>? get mention;
+  $NotificationRecieveConfigCopyWith<$Res>? get reply;
+  $NotificationRecieveConfigCopyWith<$Res>? get renote;
+  $NotificationRecieveConfigCopyWith<$Res>? get quote;
+  $NotificationRecieveConfigCopyWith<$Res>? get reaction;
+  $NotificationRecieveConfigCopyWith<$Res>? get pollEnded;
+  $NotificationRecieveConfigCopyWith<$Res>? get receiveFollowRequest;
+  $NotificationRecieveConfigCopyWith<$Res>? get followRequestAccepted;
+  $NotificationRecieveConfigCopyWith<$Res>? get roleAssigned;
+  $NotificationRecieveConfigCopyWith<$Res>? get achievementEarned;
+  $NotificationRecieveConfigCopyWith<$Res>? get app;
+  $NotificationRecieveConfigCopyWith<$Res>? get test;
+}
+
+/// @nodoc
+class _$NotificationRecieveConfigsCopyWithImpl<$Res,
+        $Val extends NotificationRecieveConfigs>
+    implements $NotificationRecieveConfigsCopyWith<$Res> {
+  _$NotificationRecieveConfigsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? note = freezed,
+    Object? follow = freezed,
+    Object? mention = freezed,
+    Object? reply = freezed,
+    Object? renote = freezed,
+    Object? quote = freezed,
+    Object? reaction = freezed,
+    Object? pollEnded = freezed,
+    Object? receiveFollowRequest = freezed,
+    Object? followRequestAccepted = freezed,
+    Object? roleAssigned = freezed,
+    Object? achievementEarned = freezed,
+    Object? app = freezed,
+    Object? test = freezed,
+  }) {
+    return _then(_value.copyWith(
+      note: freezed == note
+          ? _value.note
+          : note // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      follow: freezed == follow
+          ? _value.follow
+          : follow // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      mention: freezed == mention
+          ? _value.mention
+          : mention // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      reply: freezed == reply
+          ? _value.reply
+          : reply // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      renote: freezed == renote
+          ? _value.renote
+          : renote // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      quote: freezed == quote
+          ? _value.quote
+          : quote // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      reaction: freezed == reaction
+          ? _value.reaction
+          : reaction // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      pollEnded: freezed == pollEnded
+          ? _value.pollEnded
+          : pollEnded // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      receiveFollowRequest: freezed == receiveFollowRequest
+          ? _value.receiveFollowRequest
+          : receiveFollowRequest // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      followRequestAccepted: freezed == followRequestAccepted
+          ? _value.followRequestAccepted
+          : followRequestAccepted // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      roleAssigned: freezed == roleAssigned
+          ? _value.roleAssigned
+          : roleAssigned // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      achievementEarned: freezed == achievementEarned
+          ? _value.achievementEarned
+          : achievementEarned // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      app: freezed == app
+          ? _value.app
+          : app // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      test: freezed == test
+          ? _value.test
+          : test // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $NotificationRecieveConfigCopyWith<$Res>? get note {
+    if (_value.note == null) {
+      return null;
+    }
+
+    return $NotificationRecieveConfigCopyWith<$Res>(_value.note!, (value) {
+      return _then(_value.copyWith(note: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $NotificationRecieveConfigCopyWith<$Res>? get follow {
+    if (_value.follow == null) {
+      return null;
+    }
+
+    return $NotificationRecieveConfigCopyWith<$Res>(_value.follow!, (value) {
+      return _then(_value.copyWith(follow: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $NotificationRecieveConfigCopyWith<$Res>? get mention {
+    if (_value.mention == null) {
+      return null;
+    }
+
+    return $NotificationRecieveConfigCopyWith<$Res>(_value.mention!, (value) {
+      return _then(_value.copyWith(mention: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $NotificationRecieveConfigCopyWith<$Res>? get reply {
+    if (_value.reply == null) {
+      return null;
+    }
+
+    return $NotificationRecieveConfigCopyWith<$Res>(_value.reply!, (value) {
+      return _then(_value.copyWith(reply: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $NotificationRecieveConfigCopyWith<$Res>? get renote {
+    if (_value.renote == null) {
+      return null;
+    }
+
+    return $NotificationRecieveConfigCopyWith<$Res>(_value.renote!, (value) {
+      return _then(_value.copyWith(renote: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $NotificationRecieveConfigCopyWith<$Res>? get quote {
+    if (_value.quote == null) {
+      return null;
+    }
+
+    return $NotificationRecieveConfigCopyWith<$Res>(_value.quote!, (value) {
+      return _then(_value.copyWith(quote: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $NotificationRecieveConfigCopyWith<$Res>? get reaction {
+    if (_value.reaction == null) {
+      return null;
+    }
+
+    return $NotificationRecieveConfigCopyWith<$Res>(_value.reaction!, (value) {
+      return _then(_value.copyWith(reaction: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $NotificationRecieveConfigCopyWith<$Res>? get pollEnded {
+    if (_value.pollEnded == null) {
+      return null;
+    }
+
+    return $NotificationRecieveConfigCopyWith<$Res>(_value.pollEnded!, (value) {
+      return _then(_value.copyWith(pollEnded: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $NotificationRecieveConfigCopyWith<$Res>? get receiveFollowRequest {
+    if (_value.receiveFollowRequest == null) {
+      return null;
+    }
+
+    return $NotificationRecieveConfigCopyWith<$Res>(
+        _value.receiveFollowRequest!, (value) {
+      return _then(_value.copyWith(receiveFollowRequest: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $NotificationRecieveConfigCopyWith<$Res>? get followRequestAccepted {
+    if (_value.followRequestAccepted == null) {
+      return null;
+    }
+
+    return $NotificationRecieveConfigCopyWith<$Res>(
+        _value.followRequestAccepted!, (value) {
+      return _then(_value.copyWith(followRequestAccepted: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $NotificationRecieveConfigCopyWith<$Res>? get roleAssigned {
+    if (_value.roleAssigned == null) {
+      return null;
+    }
+
+    return $NotificationRecieveConfigCopyWith<$Res>(_value.roleAssigned!,
+        (value) {
+      return _then(_value.copyWith(roleAssigned: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $NotificationRecieveConfigCopyWith<$Res>? get achievementEarned {
+    if (_value.achievementEarned == null) {
+      return null;
+    }
+
+    return $NotificationRecieveConfigCopyWith<$Res>(_value.achievementEarned!,
+        (value) {
+      return _then(_value.copyWith(achievementEarned: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $NotificationRecieveConfigCopyWith<$Res>? get app {
+    if (_value.app == null) {
+      return null;
+    }
+
+    return $NotificationRecieveConfigCopyWith<$Res>(_value.app!, (value) {
+      return _then(_value.copyWith(app: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $NotificationRecieveConfigCopyWith<$Res>? get test {
+    if (_value.test == null) {
+      return null;
+    }
+
+    return $NotificationRecieveConfigCopyWith<$Res>(_value.test!, (value) {
+      return _then(_value.copyWith(test: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$NotificationRecieveConfigsImplCopyWith<$Res>
+    implements $NotificationRecieveConfigsCopyWith<$Res> {
+  factory _$$NotificationRecieveConfigsImplCopyWith(
+          _$NotificationRecieveConfigsImpl value,
+          $Res Function(_$NotificationRecieveConfigsImpl) then) =
+      __$$NotificationRecieveConfigsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {NotificationRecieveConfig? note,
+      NotificationRecieveConfig? follow,
+      NotificationRecieveConfig? mention,
+      NotificationRecieveConfig? reply,
+      NotificationRecieveConfig? renote,
+      NotificationRecieveConfig? quote,
+      NotificationRecieveConfig? reaction,
+      NotificationRecieveConfig? pollEnded,
+      NotificationRecieveConfig? receiveFollowRequest,
+      NotificationRecieveConfig? followRequestAccepted,
+      NotificationRecieveConfig? roleAssigned,
+      NotificationRecieveConfig? achievementEarned,
+      NotificationRecieveConfig? app,
+      NotificationRecieveConfig? test});
+
+  @override
+  $NotificationRecieveConfigCopyWith<$Res>? get note;
+  @override
+  $NotificationRecieveConfigCopyWith<$Res>? get follow;
+  @override
+  $NotificationRecieveConfigCopyWith<$Res>? get mention;
+  @override
+  $NotificationRecieveConfigCopyWith<$Res>? get reply;
+  @override
+  $NotificationRecieveConfigCopyWith<$Res>? get renote;
+  @override
+  $NotificationRecieveConfigCopyWith<$Res>? get quote;
+  @override
+  $NotificationRecieveConfigCopyWith<$Res>? get reaction;
+  @override
+  $NotificationRecieveConfigCopyWith<$Res>? get pollEnded;
+  @override
+  $NotificationRecieveConfigCopyWith<$Res>? get receiveFollowRequest;
+  @override
+  $NotificationRecieveConfigCopyWith<$Res>? get followRequestAccepted;
+  @override
+  $NotificationRecieveConfigCopyWith<$Res>? get roleAssigned;
+  @override
+  $NotificationRecieveConfigCopyWith<$Res>? get achievementEarned;
+  @override
+  $NotificationRecieveConfigCopyWith<$Res>? get app;
+  @override
+  $NotificationRecieveConfigCopyWith<$Res>? get test;
+}
+
+/// @nodoc
+class __$$NotificationRecieveConfigsImplCopyWithImpl<$Res>
+    extends _$NotificationRecieveConfigsCopyWithImpl<$Res,
+        _$NotificationRecieveConfigsImpl>
+    implements _$$NotificationRecieveConfigsImplCopyWith<$Res> {
+  __$$NotificationRecieveConfigsImplCopyWithImpl(
+      _$NotificationRecieveConfigsImpl _value,
+      $Res Function(_$NotificationRecieveConfigsImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? note = freezed,
+    Object? follow = freezed,
+    Object? mention = freezed,
+    Object? reply = freezed,
+    Object? renote = freezed,
+    Object? quote = freezed,
+    Object? reaction = freezed,
+    Object? pollEnded = freezed,
+    Object? receiveFollowRequest = freezed,
+    Object? followRequestAccepted = freezed,
+    Object? roleAssigned = freezed,
+    Object? achievementEarned = freezed,
+    Object? app = freezed,
+    Object? test = freezed,
+  }) {
+    return _then(_$NotificationRecieveConfigsImpl(
+      note: freezed == note
+          ? _value.note
+          : note // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      follow: freezed == follow
+          ? _value.follow
+          : follow // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      mention: freezed == mention
+          ? _value.mention
+          : mention // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      reply: freezed == reply
+          ? _value.reply
+          : reply // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      renote: freezed == renote
+          ? _value.renote
+          : renote // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      quote: freezed == quote
+          ? _value.quote
+          : quote // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      reaction: freezed == reaction
+          ? _value.reaction
+          : reaction // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      pollEnded: freezed == pollEnded
+          ? _value.pollEnded
+          : pollEnded // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      receiveFollowRequest: freezed == receiveFollowRequest
+          ? _value.receiveFollowRequest
+          : receiveFollowRequest // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      followRequestAccepted: freezed == followRequestAccepted
+          ? _value.followRequestAccepted
+          : followRequestAccepted // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      roleAssigned: freezed == roleAssigned
+          ? _value.roleAssigned
+          : roleAssigned // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      achievementEarned: freezed == achievementEarned
+          ? _value.achievementEarned
+          : achievementEarned // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      app: freezed == app
+          ? _value.app
+          : app // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+      test: freezed == test
+          ? _value.test
+          : test // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfig?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$NotificationRecieveConfigsImpl implements _NotificationRecieveConfigs {
+  const _$NotificationRecieveConfigsImpl(
+      {this.note,
+      this.follow,
+      this.mention,
+      this.reply,
+      this.renote,
+      this.quote,
+      this.reaction,
+      this.pollEnded,
+      this.receiveFollowRequest,
+      this.followRequestAccepted,
+      this.roleAssigned,
+      this.achievementEarned,
+      this.app,
+      this.test});
+
+  factory _$NotificationRecieveConfigsImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$NotificationRecieveConfigsImplFromJson(json);
+
+  @override
+  final NotificationRecieveConfig? note;
+  @override
+  final NotificationRecieveConfig? follow;
+  @override
+  final NotificationRecieveConfig? mention;
+  @override
+  final NotificationRecieveConfig? reply;
+  @override
+  final NotificationRecieveConfig? renote;
+  @override
+  final NotificationRecieveConfig? quote;
+  @override
+  final NotificationRecieveConfig? reaction;
+  @override
+  final NotificationRecieveConfig? pollEnded;
+  @override
+  final NotificationRecieveConfig? receiveFollowRequest;
+  @override
+  final NotificationRecieveConfig? followRequestAccepted;
+  @override
+  final NotificationRecieveConfig? roleAssigned;
+  @override
+  final NotificationRecieveConfig? achievementEarned;
+  @override
+  final NotificationRecieveConfig? app;
+  @override
+  final NotificationRecieveConfig? test;
+
+  @override
+  String toString() {
+    return 'NotificationRecieveConfigs(note: $note, follow: $follow, mention: $mention, reply: $reply, renote: $renote, quote: $quote, reaction: $reaction, pollEnded: $pollEnded, receiveFollowRequest: $receiveFollowRequest, followRequestAccepted: $followRequestAccepted, roleAssigned: $roleAssigned, achievementEarned: $achievementEarned, app: $app, test: $test)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$NotificationRecieveConfigsImpl &&
+            (identical(other.note, note) || other.note == note) &&
+            (identical(other.follow, follow) || other.follow == follow) &&
+            (identical(other.mention, mention) || other.mention == mention) &&
+            (identical(other.reply, reply) || other.reply == reply) &&
+            (identical(other.renote, renote) || other.renote == renote) &&
+            (identical(other.quote, quote) || other.quote == quote) &&
+            (identical(other.reaction, reaction) ||
+                other.reaction == reaction) &&
+            (identical(other.pollEnded, pollEnded) ||
+                other.pollEnded == pollEnded) &&
+            (identical(other.receiveFollowRequest, receiveFollowRequest) ||
+                other.receiveFollowRequest == receiveFollowRequest) &&
+            (identical(other.followRequestAccepted, followRequestAccepted) ||
+                other.followRequestAccepted == followRequestAccepted) &&
+            (identical(other.roleAssigned, roleAssigned) ||
+                other.roleAssigned == roleAssigned) &&
+            (identical(other.achievementEarned, achievementEarned) ||
+                other.achievementEarned == achievementEarned) &&
+            (identical(other.app, app) || other.app == app) &&
+            (identical(other.test, test) || other.test == test));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      note,
+      follow,
+      mention,
+      reply,
+      renote,
+      quote,
+      reaction,
+      pollEnded,
+      receiveFollowRequest,
+      followRequestAccepted,
+      roleAssigned,
+      achievementEarned,
+      app,
+      test);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$NotificationRecieveConfigsImplCopyWith<_$NotificationRecieveConfigsImpl>
+      get copyWith => __$$NotificationRecieveConfigsImplCopyWithImpl<
+          _$NotificationRecieveConfigsImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$NotificationRecieveConfigsImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _NotificationRecieveConfigs
+    implements NotificationRecieveConfigs {
+  const factory _NotificationRecieveConfigs(
+          {final NotificationRecieveConfig? note,
+          final NotificationRecieveConfig? follow,
+          final NotificationRecieveConfig? mention,
+          final NotificationRecieveConfig? reply,
+          final NotificationRecieveConfig? renote,
+          final NotificationRecieveConfig? quote,
+          final NotificationRecieveConfig? reaction,
+          final NotificationRecieveConfig? pollEnded,
+          final NotificationRecieveConfig? receiveFollowRequest,
+          final NotificationRecieveConfig? followRequestAccepted,
+          final NotificationRecieveConfig? roleAssigned,
+          final NotificationRecieveConfig? achievementEarned,
+          final NotificationRecieveConfig? app,
+          final NotificationRecieveConfig? test}) =
+      _$NotificationRecieveConfigsImpl;
+
+  factory _NotificationRecieveConfigs.fromJson(Map<String, dynamic> json) =
+      _$NotificationRecieveConfigsImpl.fromJson;
+
+  @override
+  NotificationRecieveConfig? get note;
+  @override
+  NotificationRecieveConfig? get follow;
+  @override
+  NotificationRecieveConfig? get mention;
+  @override
+  NotificationRecieveConfig? get reply;
+  @override
+  NotificationRecieveConfig? get renote;
+  @override
+  NotificationRecieveConfig? get quote;
+  @override
+  NotificationRecieveConfig? get reaction;
+  @override
+  NotificationRecieveConfig? get pollEnded;
+  @override
+  NotificationRecieveConfig? get receiveFollowRequest;
+  @override
+  NotificationRecieveConfig? get followRequestAccepted;
+  @override
+  NotificationRecieveConfig? get roleAssigned;
+  @override
+  NotificationRecieveConfig? get achievementEarned;
+  @override
+  NotificationRecieveConfig? get app;
+  @override
+  NotificationRecieveConfig? get test;
+  @override
+  @JsonKey(ignore: true)
+  _$$NotificationRecieveConfigsImplCopyWith<_$NotificationRecieveConfigsImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+NotificationRecieveConfig _$NotificationRecieveConfigFromJson(
+    Map<String, dynamic> json) {
+  return _NotificationRecieveConfig.fromJson(json);
+}
+
+/// @nodoc
+mixin _$NotificationRecieveConfig {
+  String get type => throw _privateConstructorUsedError;
+  String? get userListId => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $NotificationRecieveConfigCopyWith<NotificationRecieveConfig> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $NotificationRecieveConfigCopyWith<$Res> {
+  factory $NotificationRecieveConfigCopyWith(NotificationRecieveConfig value,
+          $Res Function(NotificationRecieveConfig) then) =
+      _$NotificationRecieveConfigCopyWithImpl<$Res, NotificationRecieveConfig>;
+  @useResult
+  $Res call({String type, String? userListId});
+}
+
+/// @nodoc
+class _$NotificationRecieveConfigCopyWithImpl<$Res,
+        $Val extends NotificationRecieveConfig>
+    implements $NotificationRecieveConfigCopyWith<$Res> {
+  _$NotificationRecieveConfigCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? type = null,
+    Object? userListId = freezed,
+  }) {
+    return _then(_value.copyWith(
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String,
+      userListId: freezed == userListId
+          ? _value.userListId
+          : userListId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$NotificationRecieveConfigImplCopyWith<$Res>
+    implements $NotificationRecieveConfigCopyWith<$Res> {
+  factory _$$NotificationRecieveConfigImplCopyWith(
+          _$NotificationRecieveConfigImpl value,
+          $Res Function(_$NotificationRecieveConfigImpl) then) =
+      __$$NotificationRecieveConfigImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String type, String? userListId});
+}
+
+/// @nodoc
+class __$$NotificationRecieveConfigImplCopyWithImpl<$Res>
+    extends _$NotificationRecieveConfigCopyWithImpl<$Res,
+        _$NotificationRecieveConfigImpl>
+    implements _$$NotificationRecieveConfigImplCopyWith<$Res> {
+  __$$NotificationRecieveConfigImplCopyWithImpl(
+      _$NotificationRecieveConfigImpl _value,
+      $Res Function(_$NotificationRecieveConfigImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? type = null,
+    Object? userListId = freezed,
+  }) {
+    return _then(_$NotificationRecieveConfigImpl(
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String,
+      userListId: freezed == userListId
+          ? _value.userListId
+          : userListId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$NotificationRecieveConfigImpl implements _NotificationRecieveConfig {
+  const _$NotificationRecieveConfigImpl({required this.type, this.userListId});
+
+  factory _$NotificationRecieveConfigImpl.fromJson(Map<String, dynamic> json) =>
+      _$$NotificationRecieveConfigImplFromJson(json);
+
+  @override
+  final String type;
+  @override
+  final String? userListId;
+
+  @override
+  String toString() {
+    return 'NotificationRecieveConfig(type: $type, userListId: $userListId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$NotificationRecieveConfigImpl &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.userListId, userListId) ||
+                other.userListId == userListId));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, type, userListId);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$NotificationRecieveConfigImplCopyWith<_$NotificationRecieveConfigImpl>
+      get copyWith => __$$NotificationRecieveConfigImplCopyWithImpl<
+          _$NotificationRecieveConfigImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$NotificationRecieveConfigImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _NotificationRecieveConfig implements NotificationRecieveConfig {
+  const factory _NotificationRecieveConfig(
+      {required final String type,
+      final String? userListId}) = _$NotificationRecieveConfigImpl;
+
+  factory _NotificationRecieveConfig.fromJson(Map<String, dynamic> json) =
+      _$NotificationRecieveConfigImpl.fromJson;
+
+  @override
+  String get type;
+  @override
+  String? get userListId;
+  @override
+  @JsonKey(ignore: true)
+  _$$NotificationRecieveConfigImplCopyWith<_$NotificationRecieveConfigImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/data/base/user.g.dart
+++ b/lib/src/data/base/user.g.dart
@@ -86,6 +86,11 @@ _$UserDetailedNotMeImpl _$$UserDetailedNotMeImplFromJson(
           json['url'], const NullableUriConverter().fromJson),
       uri: _$JsonConverterFromJson<String, Uri?>(
           json['uri'], const NullableUriConverter().fromJson),
+      movedTo: _$JsonConverterFromJson<String, Uri?>(
+          json['movedTo'], const NullableUriConverter().fromJson),
+      alsoKnownAs: (json['alsoKnownAs'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
       createdAt:
           const DateTimeConverter().fromJson(json['createdAt'] as String),
       updatedAt: _$JsonConverterFromJson<String, DateTime?>(
@@ -106,6 +111,10 @@ _$UserDetailedNotMeImpl _$$UserDetailedNotMeImplFromJson(
       fields: (json['fields'] as List<dynamic>?)
           ?.map((e) => UserField.fromJson(e as Map<String, dynamic>))
           .toList(),
+      verifiedLinks: (json['verifiedLinks'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
       followersCount: json['followersCount'] as int,
       followingCount: json['followingCount'] as int,
       notesCount: json['notesCount'] as int,
@@ -131,6 +140,7 @@ _$UserDetailedNotMeImpl _$$UserDetailedNotMeImplFromJson(
           ?.map((e) => UserRole.fromJson(e as Map<String, dynamic>))
           .toList(),
       memo: json['memo'] as String?,
+      moderationNote: json['moderationNote'] as String?,
     );
 
 Map<String, dynamic> _$$UserDetailedNotMeImplToJson(
@@ -153,6 +163,8 @@ Map<String, dynamic> _$$UserDetailedNotMeImplToJson(
       'badgeRoles': instance.badgeRoles.map((e) => e.toJson()).toList(),
       'url': const NullableUriConverter().toJson(instance.url),
       'uri': const NullableUriConverter().toJson(instance.uri),
+      'movedTo': const NullableUriConverter().toJson(instance.movedTo),
+      'alsoKnownAs': instance.alsoKnownAs,
       'createdAt': const DateTimeConverter().toJson(instance.createdAt),
       'updatedAt': const NullableDateTimeConverter().toJson(instance.updatedAt),
       'lastFetchedAt':
@@ -167,6 +179,7 @@ Map<String, dynamic> _$$UserDetailedNotMeImplToJson(
       'birthday': const NullableDateTimeConverter().toJson(instance.birthday),
       'lang': instance.lang,
       'fields': instance.fields?.map((e) => e.toJson()).toList(),
+      'verifiedLinks': instance.verifiedLinks,
       'followersCount': instance.followersCount,
       'followingCount': instance.followingCount,
       'notesCount': instance.notesCount,
@@ -185,6 +198,7 @@ Map<String, dynamic> _$$UserDetailedNotMeImplToJson(
       'securityKeys': instance.securityKeys,
       'roles': instance.roles?.map((e) => e.toJson()).toList(),
       'memo': instance.memo,
+      'moderationNote': instance.moderationNote,
     };
 
 Value? _$JsonConverterFromJson<Json, Value>(
@@ -233,6 +247,11 @@ _$UserDetailedNotMeWithRelationsImpl
               json['url'], const NullableUriConverter().fromJson),
           uri: _$JsonConverterFromJson<String, Uri?>(
               json['uri'], const NullableUriConverter().fromJson),
+          movedTo: _$JsonConverterFromJson<String, Uri?>(
+              json['movedTo'], const NullableUriConverter().fromJson),
+          alsoKnownAs: (json['alsoKnownAs'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList(),
           createdAt:
               const DateTimeConverter().fromJson(json['createdAt'] as String),
           updatedAt: _$JsonConverterFromJson<String, DateTime?>(
@@ -254,6 +273,10 @@ _$UserDetailedNotMeWithRelationsImpl
           fields: (json['fields'] as List<dynamic>?)
               ?.map((e) => UserField.fromJson(e as Map<String, dynamic>))
               .toList(),
+          verifiedLinks: (json['verifiedLinks'] as List<dynamic>?)
+                  ?.map((e) => e as String)
+                  .toList() ??
+              const [],
           followersCount: json['followersCount'] as int,
           followingCount: json['followingCount'] as int,
           notesCount: json['notesCount'] as int,
@@ -279,6 +302,7 @@ _$UserDetailedNotMeWithRelationsImpl
               ?.map((e) => UserRole.fromJson(e as Map<String, dynamic>))
               .toList(),
           memo: json['memo'] as String?,
+          moderationNote: json['moderationNote'] as String?,
           isFollowing: json['isFollowing'] as bool,
           isFollowed: json['isFollowed'] as bool,
           hasPendingFollowRequestFromYou:
@@ -289,6 +313,8 @@ _$UserDetailedNotMeWithRelationsImpl
           isBlocked: json['isBlocked'] as bool,
           isMuted: json['isMuted'] as bool,
           isRenoteMuted: json['isRenoteMuted'] as bool,
+          notify: $enumDecodeNullable(_$NotifyEnumMap, json['notify']),
+          withReplies: json['withReplies'] as bool?,
         );
 
 Map<String, dynamic> _$$UserDetailedNotMeWithRelationsImplToJson(
@@ -311,6 +337,8 @@ Map<String, dynamic> _$$UserDetailedNotMeWithRelationsImplToJson(
       'badgeRoles': instance.badgeRoles.map((e) => e.toJson()).toList(),
       'url': const NullableUriConverter().toJson(instance.url),
       'uri': const NullableUriConverter().toJson(instance.uri),
+      'movedTo': const NullableUriConverter().toJson(instance.movedTo),
+      'alsoKnownAs': instance.alsoKnownAs,
       'createdAt': const DateTimeConverter().toJson(instance.createdAt),
       'updatedAt': const NullableDateTimeConverter().toJson(instance.updatedAt),
       'lastFetchedAt':
@@ -325,6 +353,7 @@ Map<String, dynamic> _$$UserDetailedNotMeWithRelationsImplToJson(
       'birthday': const NullableDateTimeConverter().toJson(instance.birthday),
       'lang': instance.lang,
       'fields': instance.fields?.map((e) => e.toJson()).toList(),
+      'verifiedLinks': instance.verifiedLinks,
       'followersCount': instance.followersCount,
       'followingCount': instance.followingCount,
       'notesCount': instance.notesCount,
@@ -343,6 +372,7 @@ Map<String, dynamic> _$$UserDetailedNotMeWithRelationsImplToJson(
       'securityKeys': instance.securityKeys,
       'roles': instance.roles?.map((e) => e.toJson()).toList(),
       'memo': instance.memo,
+      'moderationNote': instance.moderationNote,
       'isFollowing': instance.isFollowing,
       'isFollowed': instance.isFollowed,
       'hasPendingFollowRequestFromYou': instance.hasPendingFollowRequestFromYou,
@@ -351,7 +381,14 @@ Map<String, dynamic> _$$UserDetailedNotMeWithRelationsImplToJson(
       'isBlocked': instance.isBlocked,
       'isMuted': instance.isMuted,
       'isRenoteMuted': instance.isRenoteMuted,
+      'notify': _$NotifyEnumMap[instance.notify],
+      'withReplies': instance.withReplies,
     };
+
+const _$NotifyEnumMap = {
+  Notify.normal: 'normal',
+  Notify.none: 'none',
+};
 
 _$MeDetailedImpl _$$MeDetailedImplFromJson(Map<String, dynamic> json) =>
     _$MeDetailedImpl(
@@ -384,6 +421,11 @@ _$MeDetailedImpl _$$MeDetailedImplFromJson(Map<String, dynamic> json) =>
           json['url'], const NullableUriConverter().fromJson),
       uri: _$JsonConverterFromJson<String, Uri?>(
           json['uri'], const NullableUriConverter().fromJson),
+      movedTo: _$JsonConverterFromJson<String, Uri?>(
+          json['movedTo'], const NullableUriConverter().fromJson),
+      alsoKnownAs: (json['alsoKnownAs'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
       createdAt:
           const DateTimeConverter().fromJson(json['createdAt'] as String),
       updatedAt: _$JsonConverterFromJson<String, DateTime?>(
@@ -404,6 +446,10 @@ _$MeDetailedImpl _$$MeDetailedImplFromJson(Map<String, dynamic> json) =>
       fields: (json['fields'] as List<dynamic>?)
           ?.map((e) => UserField.fromJson(e as Map<String, dynamic>))
           .toList(),
+      verifiedLinks: (json['verifiedLinks'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
       followersCount: json['followersCount'] as int,
       followingCount: json['followingCount'] as int,
       notesCount: json['notesCount'] as int,
@@ -429,6 +475,7 @@ _$MeDetailedImpl _$$MeDetailedImplFromJson(Map<String, dynamic> json) =>
           ?.map((e) => UserRole.fromJson(e as Map<String, dynamic>))
           .toList(),
       memo: json['memo'] as String?,
+      moderationNote: json['moderationNote'] as String?,
       avatarId: json['avatarId'] as String?,
       bannerId: json['bannerId'] as String?,
       isModerator: json['isModerator'] as bool,
@@ -439,9 +486,13 @@ _$MeDetailedImpl _$$MeDetailedImplFromJson(Map<String, dynamic> json) =>
       autoSensitive: json['autoSensitive'] as bool,
       carefulBot: json['carefulBot'] as bool,
       autoAcceptFollowed: json['autoAcceptFollowed'] as bool,
+      preventAiLearning: json['preventAiLearning'] as bool?,
       noCrawle: json['noCrawle'] as bool,
       isExplorable: json['isExplorable'] as bool,
       isDeleted: json['isDeleted'] as bool,
+      twoFactorBackupCodesStock: $enumDecodeNullable(
+          _$TwoFactorBackupCodesStockEnumMap,
+          json['twoFactorBackupCodesStock']),
       hideOnlineStatus: json['hideOnlineStatus'] as bool,
       hasUnreadSpecifiedNotes: json['hasUnreadSpecifiedNotes'] as bool,
       hasUnreadMentions: json['hasUnreadMentions'] as bool,
@@ -471,7 +522,10 @@ _$MeDetailedImpl _$$MeDetailedImplFromJson(Map<String, dynamic> json) =>
           (json['mutingNotificationTypes'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList(),
-      notificationRecieveConfig: json['notificationRecieveConfig'],
+      notificationRecieveConfig: json['notificationRecieveConfig'] == null
+          ? const NotificationRecieveConfigs()
+          : NotificationRecieveConfigs.fromJson(
+              json['notificationRecieveConfig'] as Map<String, dynamic>),
       emailNotificationTypes: (json['emailNotificationTypes'] as List<dynamic>)
           .map((e) => e as String)
           .toList(),
@@ -501,6 +555,8 @@ Map<String, dynamic> _$$MeDetailedImplToJson(_$MeDetailedImpl instance) =>
       'badgeRoles': instance.badgeRoles.map((e) => e.toJson()).toList(),
       'url': const NullableUriConverter().toJson(instance.url),
       'uri': const NullableUriConverter().toJson(instance.uri),
+      'movedTo': const NullableUriConverter().toJson(instance.movedTo),
+      'alsoKnownAs': instance.alsoKnownAs,
       'createdAt': const DateTimeConverter().toJson(instance.createdAt),
       'updatedAt': const NullableDateTimeConverter().toJson(instance.updatedAt),
       'lastFetchedAt':
@@ -515,6 +571,7 @@ Map<String, dynamic> _$$MeDetailedImplToJson(_$MeDetailedImpl instance) =>
       'birthday': const NullableDateTimeConverter().toJson(instance.birthday),
       'lang': instance.lang,
       'fields': instance.fields?.map((e) => e.toJson()).toList(),
+      'verifiedLinks': instance.verifiedLinks,
       'followersCount': instance.followersCount,
       'followingCount': instance.followingCount,
       'notesCount': instance.notesCount,
@@ -533,6 +590,7 @@ Map<String, dynamic> _$$MeDetailedImplToJson(_$MeDetailedImpl instance) =>
       'securityKeys': instance.securityKeys,
       'roles': instance.roles?.map((e) => e.toJson()).toList(),
       'memo': instance.memo,
+      'moderationNote': instance.moderationNote,
       'avatarId': instance.avatarId,
       'bannerId': instance.bannerId,
       'isModerator': instance.isModerator,
@@ -543,9 +601,12 @@ Map<String, dynamic> _$$MeDetailedImplToJson(_$MeDetailedImpl instance) =>
       'autoSensitive': instance.autoSensitive,
       'carefulBot': instance.carefulBot,
       'autoAcceptFollowed': instance.autoAcceptFollowed,
+      'preventAiLearning': instance.preventAiLearning,
       'noCrawle': instance.noCrawle,
       'isExplorable': instance.isExplorable,
       'isDeleted': instance.isDeleted,
+      'twoFactorBackupCodesStock': _$TwoFactorBackupCodesStockEnumMap[
+          instance.twoFactorBackupCodesStock],
       'hideOnlineStatus': instance.hideOnlineStatus,
       'hasUnreadSpecifiedNotes': instance.hasUnreadSpecifiedNotes,
       'hasUnreadMentions': instance.hasUnreadMentions,
@@ -565,12 +626,18 @@ Map<String, dynamic> _$$MeDetailedImplToJson(_$MeDetailedImpl instance) =>
           .toList(),
       'mutedInstances': instance.mutedInstances,
       'mutingNotificationTypes': instance.mutingNotificationTypes,
-      'notificationRecieveConfig': instance.notificationRecieveConfig,
+      'notificationRecieveConfig': instance.notificationRecieveConfig.toJson(),
       'emailNotificationTypes': instance.emailNotificationTypes,
       'achievements': instance.achievements.map((e) => e.toJson()).toList(),
       'loggedInDays': instance.loggedInDays,
       'policies': instance.policies.toJson(),
     };
+
+const _$TwoFactorBackupCodesStockEnumMap = {
+  TwoFactorBackupCodesStock.full: 'full',
+  TwoFactorBackupCodesStock.partial: 'partial',
+  TwoFactorBackupCodesStock.none: 'none',
+};
 
 _$UserAvatarDecorationImpl _$$UserAvatarDecorationImplFromJson(
         Map<String, dynamic> json) =>
@@ -734,4 +801,98 @@ Map<String, dynamic> _$$UserFieldImplToJson(_$UserFieldImpl instance) =>
     <String, dynamic>{
       'name': instance.name,
       'value': instance.value,
+    };
+
+_$NotificationRecieveConfigsImpl _$$NotificationRecieveConfigsImplFromJson(
+        Map<String, dynamic> json) =>
+    _$NotificationRecieveConfigsImpl(
+      note: json['note'] == null
+          ? null
+          : NotificationRecieveConfig.fromJson(
+              json['note'] as Map<String, dynamic>),
+      follow: json['follow'] == null
+          ? null
+          : NotificationRecieveConfig.fromJson(
+              json['follow'] as Map<String, dynamic>),
+      mention: json['mention'] == null
+          ? null
+          : NotificationRecieveConfig.fromJson(
+              json['mention'] as Map<String, dynamic>),
+      reply: json['reply'] == null
+          ? null
+          : NotificationRecieveConfig.fromJson(
+              json['reply'] as Map<String, dynamic>),
+      renote: json['renote'] == null
+          ? null
+          : NotificationRecieveConfig.fromJson(
+              json['renote'] as Map<String, dynamic>),
+      quote: json['quote'] == null
+          ? null
+          : NotificationRecieveConfig.fromJson(
+              json['quote'] as Map<String, dynamic>),
+      reaction: json['reaction'] == null
+          ? null
+          : NotificationRecieveConfig.fromJson(
+              json['reaction'] as Map<String, dynamic>),
+      pollEnded: json['pollEnded'] == null
+          ? null
+          : NotificationRecieveConfig.fromJson(
+              json['pollEnded'] as Map<String, dynamic>),
+      receiveFollowRequest: json['receiveFollowRequest'] == null
+          ? null
+          : NotificationRecieveConfig.fromJson(
+              json['receiveFollowRequest'] as Map<String, dynamic>),
+      followRequestAccepted: json['followRequestAccepted'] == null
+          ? null
+          : NotificationRecieveConfig.fromJson(
+              json['followRequestAccepted'] as Map<String, dynamic>),
+      roleAssigned: json['roleAssigned'] == null
+          ? null
+          : NotificationRecieveConfig.fromJson(
+              json['roleAssigned'] as Map<String, dynamic>),
+      achievementEarned: json['achievementEarned'] == null
+          ? null
+          : NotificationRecieveConfig.fromJson(
+              json['achievementEarned'] as Map<String, dynamic>),
+      app: json['app'] == null
+          ? null
+          : NotificationRecieveConfig.fromJson(
+              json['app'] as Map<String, dynamic>),
+      test: json['test'] == null
+          ? null
+          : NotificationRecieveConfig.fromJson(
+              json['test'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$NotificationRecieveConfigsImplToJson(
+        _$NotificationRecieveConfigsImpl instance) =>
+    <String, dynamic>{
+      'note': instance.note?.toJson(),
+      'follow': instance.follow?.toJson(),
+      'mention': instance.mention?.toJson(),
+      'reply': instance.reply?.toJson(),
+      'renote': instance.renote?.toJson(),
+      'quote': instance.quote?.toJson(),
+      'reaction': instance.reaction?.toJson(),
+      'pollEnded': instance.pollEnded?.toJson(),
+      'receiveFollowRequest': instance.receiveFollowRequest?.toJson(),
+      'followRequestAccepted': instance.followRequestAccepted?.toJson(),
+      'roleAssigned': instance.roleAssigned?.toJson(),
+      'achievementEarned': instance.achievementEarned?.toJson(),
+      'app': instance.app?.toJson(),
+      'test': instance.test?.toJson(),
+    };
+
+_$NotificationRecieveConfigImpl _$$NotificationRecieveConfigImplFromJson(
+        Map<String, dynamic> json) =>
+    _$NotificationRecieveConfigImpl(
+      type: json['type'] as String,
+      userListId: json['userListId'] as String?,
+    );
+
+Map<String, dynamic> _$$NotificationRecieveConfigImplToJson(
+        _$NotificationRecieveConfigImpl instance) =>
+    <String, dynamic>{
+      'type': instance.type,
+      'userListId': instance.userListId,
     };

--- a/lib/src/data/i/i_update_request.dart
+++ b/lib/src/data/i/i_update_request.dart
@@ -15,6 +15,7 @@ class IUpdateRequest with _$IUpdateRequest {
     @DateTimeConverter() birthday,
     String? lang,
     String? avatarId,
+    List<IUpdateAvatarDecoration>? avatarDecorations,
     String? bannerId,
     List<UserField>? fields,
     bool? isLocked,
@@ -30,6 +31,7 @@ class IUpdateRequest with _$IUpdateRequest {
     bool? injectFeaturedNote,
     bool? receiveAnnouncementEmail,
     bool? alwaysMarkNsfw,
+    bool? autoSensitive,
     @Deprecated("removed at 2023.12.0") FFVisibility? ffVisibility,
     FFVisibility? followingVisibility,
     FFVisibility? followersVisibility,
@@ -38,10 +40,25 @@ class IUpdateRequest with _$IUpdateRequest {
     @MuteWordsConverter() List<MuteWord>? mutedWords,
     @MuteWordsConverter() List<MuteWord>? hardMutedWords,
     List<String>? mutedInstances,
+    NotificationRecieveConfigs? notificationRecieveConfig,
     List<String>? emailNotificationTypes,
     List<String>? alsoKnownAs,
   }) = _IUpdateRequest;
 
   factory IUpdateRequest.fromJson(Map<String, dynamic> json) =>
       _$IUpdateRequestFromJson(json);
+}
+
+@freezed
+class IUpdateAvatarDecoration with _$IUpdateAvatarDecoration {
+  const factory IUpdateAvatarDecoration({
+    required String id,
+    double? angle,
+    @Default(false) bool flipH,
+    @Default(0.0) double offsetX,
+    @Default(0.0) double offsetY,
+  }) = _IUpdateAvatarDecoration;
+
+  factory IUpdateAvatarDecoration.fromJson(Map<String, Object?> json) =>
+      _$IUpdateAvatarDecorationFromJson(json);
 }

--- a/lib/src/data/i/i_update_request.freezed.dart
+++ b/lib/src/data/i/i_update_request.freezed.dart
@@ -27,6 +27,8 @@ mixin _$IUpdateRequest {
   dynamic get birthday => throw _privateConstructorUsedError;
   String? get lang => throw _privateConstructorUsedError;
   String? get avatarId => throw _privateConstructorUsedError;
+  List<IUpdateAvatarDecoration>? get avatarDecorations =>
+      throw _privateConstructorUsedError;
   String? get bannerId => throw _privateConstructorUsedError;
   List<UserField>? get fields => throw _privateConstructorUsedError;
   bool? get isLocked => throw _privateConstructorUsedError;
@@ -42,6 +44,7 @@ mixin _$IUpdateRequest {
   bool? get injectFeaturedNote => throw _privateConstructorUsedError;
   bool? get receiveAnnouncementEmail => throw _privateConstructorUsedError;
   bool? get alwaysMarkNsfw => throw _privateConstructorUsedError;
+  bool? get autoSensitive => throw _privateConstructorUsedError;
   @Deprecated("removed at 2023.12.0")
   FFVisibility? get ffVisibility => throw _privateConstructorUsedError;
   FFVisibility? get followingVisibility => throw _privateConstructorUsedError;
@@ -54,6 +57,8 @@ mixin _$IUpdateRequest {
   @MuteWordsConverter()
   List<MuteWord>? get hardMutedWords => throw _privateConstructorUsedError;
   List<String>? get mutedInstances => throw _privateConstructorUsedError;
+  NotificationRecieveConfigs? get notificationRecieveConfig =>
+      throw _privateConstructorUsedError;
   List<String>? get emailNotificationTypes =>
       throw _privateConstructorUsedError;
   List<String>? get alsoKnownAs => throw _privateConstructorUsedError;
@@ -77,6 +82,7 @@ abstract class $IUpdateRequestCopyWith<$Res> {
       @DateTimeConverter() dynamic birthday,
       String? lang,
       String? avatarId,
+      List<IUpdateAvatarDecoration>? avatarDecorations,
       String? bannerId,
       List<UserField>? fields,
       bool? isLocked,
@@ -92,6 +98,7 @@ abstract class $IUpdateRequestCopyWith<$Res> {
       bool? injectFeaturedNote,
       bool? receiveAnnouncementEmail,
       bool? alwaysMarkNsfw,
+      bool? autoSensitive,
       @Deprecated("removed at 2023.12.0") FFVisibility? ffVisibility,
       FFVisibility? followingVisibility,
       FFVisibility? followersVisibility,
@@ -100,8 +107,11 @@ abstract class $IUpdateRequestCopyWith<$Res> {
       @MuteWordsConverter() List<MuteWord>? mutedWords,
       @MuteWordsConverter() List<MuteWord>? hardMutedWords,
       List<String>? mutedInstances,
+      NotificationRecieveConfigs? notificationRecieveConfig,
       List<String>? emailNotificationTypes,
       List<String>? alsoKnownAs});
+
+  $NotificationRecieveConfigsCopyWith<$Res>? get notificationRecieveConfig;
 }
 
 /// @nodoc
@@ -123,6 +133,7 @@ class _$IUpdateRequestCopyWithImpl<$Res, $Val extends IUpdateRequest>
     Object? birthday = freezed,
     Object? lang = freezed,
     Object? avatarId = freezed,
+    Object? avatarDecorations = freezed,
     Object? bannerId = freezed,
     Object? fields = freezed,
     Object? isLocked = freezed,
@@ -138,6 +149,7 @@ class _$IUpdateRequestCopyWithImpl<$Res, $Val extends IUpdateRequest>
     Object? injectFeaturedNote = freezed,
     Object? receiveAnnouncementEmail = freezed,
     Object? alwaysMarkNsfw = freezed,
+    Object? autoSensitive = freezed,
     Object? ffVisibility = freezed,
     Object? followingVisibility = freezed,
     Object? followersVisibility = freezed,
@@ -146,6 +158,7 @@ class _$IUpdateRequestCopyWithImpl<$Res, $Val extends IUpdateRequest>
     Object? mutedWords = freezed,
     Object? hardMutedWords = freezed,
     Object? mutedInstances = freezed,
+    Object? notificationRecieveConfig = freezed,
     Object? emailNotificationTypes = freezed,
     Object? alsoKnownAs = freezed,
   }) {
@@ -174,6 +187,10 @@ class _$IUpdateRequestCopyWithImpl<$Res, $Val extends IUpdateRequest>
           ? _value.avatarId
           : avatarId // ignore: cast_nullable_to_non_nullable
               as String?,
+      avatarDecorations: freezed == avatarDecorations
+          ? _value.avatarDecorations
+          : avatarDecorations // ignore: cast_nullable_to_non_nullable
+              as List<IUpdateAvatarDecoration>?,
       bannerId: freezed == bannerId
           ? _value.bannerId
           : bannerId // ignore: cast_nullable_to_non_nullable
@@ -234,6 +251,10 @@ class _$IUpdateRequestCopyWithImpl<$Res, $Val extends IUpdateRequest>
           ? _value.alwaysMarkNsfw
           : alwaysMarkNsfw // ignore: cast_nullable_to_non_nullable
               as bool?,
+      autoSensitive: freezed == autoSensitive
+          ? _value.autoSensitive
+          : autoSensitive // ignore: cast_nullable_to_non_nullable
+              as bool?,
       ffVisibility: freezed == ffVisibility
           ? _value.ffVisibility
           : ffVisibility // ignore: cast_nullable_to_non_nullable
@@ -266,6 +287,10 @@ class _$IUpdateRequestCopyWithImpl<$Res, $Val extends IUpdateRequest>
           ? _value.mutedInstances
           : mutedInstances // ignore: cast_nullable_to_non_nullable
               as List<String>?,
+      notificationRecieveConfig: freezed == notificationRecieveConfig
+          ? _value.notificationRecieveConfig
+          : notificationRecieveConfig // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfigs?,
       emailNotificationTypes: freezed == emailNotificationTypes
           ? _value.emailNotificationTypes
           : emailNotificationTypes // ignore: cast_nullable_to_non_nullable
@@ -275,6 +300,19 @@ class _$IUpdateRequestCopyWithImpl<$Res, $Val extends IUpdateRequest>
           : alsoKnownAs // ignore: cast_nullable_to_non_nullable
               as List<String>?,
     ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $NotificationRecieveConfigsCopyWith<$Res>? get notificationRecieveConfig {
+    if (_value.notificationRecieveConfig == null) {
+      return null;
+    }
+
+    return $NotificationRecieveConfigsCopyWith<$Res>(
+        _value.notificationRecieveConfig!, (value) {
+      return _then(_value.copyWith(notificationRecieveConfig: value) as $Val);
+    });
   }
 }
 
@@ -293,6 +331,7 @@ abstract class _$$IUpdateRequestImplCopyWith<$Res>
       @DateTimeConverter() dynamic birthday,
       String? lang,
       String? avatarId,
+      List<IUpdateAvatarDecoration>? avatarDecorations,
       String? bannerId,
       List<UserField>? fields,
       bool? isLocked,
@@ -308,6 +347,7 @@ abstract class _$$IUpdateRequestImplCopyWith<$Res>
       bool? injectFeaturedNote,
       bool? receiveAnnouncementEmail,
       bool? alwaysMarkNsfw,
+      bool? autoSensitive,
       @Deprecated("removed at 2023.12.0") FFVisibility? ffVisibility,
       FFVisibility? followingVisibility,
       FFVisibility? followersVisibility,
@@ -316,8 +356,12 @@ abstract class _$$IUpdateRequestImplCopyWith<$Res>
       @MuteWordsConverter() List<MuteWord>? mutedWords,
       @MuteWordsConverter() List<MuteWord>? hardMutedWords,
       List<String>? mutedInstances,
+      NotificationRecieveConfigs? notificationRecieveConfig,
       List<String>? emailNotificationTypes,
       List<String>? alsoKnownAs});
+
+  @override
+  $NotificationRecieveConfigsCopyWith<$Res>? get notificationRecieveConfig;
 }
 
 /// @nodoc
@@ -337,6 +381,7 @@ class __$$IUpdateRequestImplCopyWithImpl<$Res>
     Object? birthday = freezed,
     Object? lang = freezed,
     Object? avatarId = freezed,
+    Object? avatarDecorations = freezed,
     Object? bannerId = freezed,
     Object? fields = freezed,
     Object? isLocked = freezed,
@@ -352,6 +397,7 @@ class __$$IUpdateRequestImplCopyWithImpl<$Res>
     Object? injectFeaturedNote = freezed,
     Object? receiveAnnouncementEmail = freezed,
     Object? alwaysMarkNsfw = freezed,
+    Object? autoSensitive = freezed,
     Object? ffVisibility = freezed,
     Object? followingVisibility = freezed,
     Object? followersVisibility = freezed,
@@ -360,6 +406,7 @@ class __$$IUpdateRequestImplCopyWithImpl<$Res>
     Object? mutedWords = freezed,
     Object? hardMutedWords = freezed,
     Object? mutedInstances = freezed,
+    Object? notificationRecieveConfig = freezed,
     Object? emailNotificationTypes = freezed,
     Object? alsoKnownAs = freezed,
   }) {
@@ -385,6 +432,10 @@ class __$$IUpdateRequestImplCopyWithImpl<$Res>
           ? _value.avatarId
           : avatarId // ignore: cast_nullable_to_non_nullable
               as String?,
+      avatarDecorations: freezed == avatarDecorations
+          ? _value._avatarDecorations
+          : avatarDecorations // ignore: cast_nullable_to_non_nullable
+              as List<IUpdateAvatarDecoration>?,
       bannerId: freezed == bannerId
           ? _value.bannerId
           : bannerId // ignore: cast_nullable_to_non_nullable
@@ -445,6 +496,10 @@ class __$$IUpdateRequestImplCopyWithImpl<$Res>
           ? _value.alwaysMarkNsfw
           : alwaysMarkNsfw // ignore: cast_nullable_to_non_nullable
               as bool?,
+      autoSensitive: freezed == autoSensitive
+          ? _value.autoSensitive
+          : autoSensitive // ignore: cast_nullable_to_non_nullable
+              as bool?,
       ffVisibility: freezed == ffVisibility
           ? _value.ffVisibility
           : ffVisibility // ignore: cast_nullable_to_non_nullable
@@ -477,6 +532,10 @@ class __$$IUpdateRequestImplCopyWithImpl<$Res>
           ? _value._mutedInstances
           : mutedInstances // ignore: cast_nullable_to_non_nullable
               as List<String>?,
+      notificationRecieveConfig: freezed == notificationRecieveConfig
+          ? _value.notificationRecieveConfig
+          : notificationRecieveConfig // ignore: cast_nullable_to_non_nullable
+              as NotificationRecieveConfigs?,
       emailNotificationTypes: freezed == emailNotificationTypes
           ? _value._emailNotificationTypes
           : emailNotificationTypes // ignore: cast_nullable_to_non_nullable
@@ -499,6 +558,7 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
       @DateTimeConverter() this.birthday,
       this.lang,
       this.avatarId,
+      final List<IUpdateAvatarDecoration>? avatarDecorations,
       this.bannerId,
       final List<UserField>? fields,
       this.isLocked,
@@ -514,6 +574,7 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
       this.injectFeaturedNote,
       this.receiveAnnouncementEmail,
       this.alwaysMarkNsfw,
+      this.autoSensitive,
       @Deprecated("removed at 2023.12.0") this.ffVisibility,
       this.followingVisibility,
       this.followersVisibility,
@@ -522,9 +583,11 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
       @MuteWordsConverter() final List<MuteWord>? mutedWords,
       @MuteWordsConverter() final List<MuteWord>? hardMutedWords,
       final List<String>? mutedInstances,
+      this.notificationRecieveConfig,
       final List<String>? emailNotificationTypes,
       final List<String>? alsoKnownAs})
-      : _fields = fields,
+      : _avatarDecorations = avatarDecorations,
+        _fields = fields,
         _mutingNotificationTypes = mutingNotificationTypes,
         _mutedWords = mutedWords,
         _hardMutedWords = hardMutedWords,
@@ -548,6 +611,17 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
   final String? lang;
   @override
   final String? avatarId;
+  final List<IUpdateAvatarDecoration>? _avatarDecorations;
+  @override
+  List<IUpdateAvatarDecoration>? get avatarDecorations {
+    final value = _avatarDecorations;
+    if (value == null) return null;
+    if (_avatarDecorations is EqualUnmodifiableListView)
+      return _avatarDecorations;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
   @override
   final String? bannerId;
   final List<UserField>? _fields;
@@ -586,6 +660,8 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
   final bool? receiveAnnouncementEmail;
   @override
   final bool? alwaysMarkNsfw;
+  @override
+  final bool? autoSensitive;
   @override
   @Deprecated("removed at 2023.12.0")
   final FFVisibility? ffVisibility;
@@ -638,6 +714,8 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
     return EqualUnmodifiableListView(value);
   }
 
+  @override
+  final NotificationRecieveConfigs? notificationRecieveConfig;
   final List<String>? _emailNotificationTypes;
   @override
   List<String>? get emailNotificationTypes {
@@ -661,7 +739,7 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
 
   @override
   String toString() {
-    return 'IUpdateRequest(name: $name, description: $description, location: $location, birthday: $birthday, lang: $lang, avatarId: $avatarId, bannerId: $bannerId, fields: $fields, isLocked: $isLocked, isExplorable: $isExplorable, hideOnlineStatus: $hideOnlineStatus, publicReactions: $publicReactions, carefulBot: $carefulBot, autoAcceptFollowed: $autoAcceptFollowed, noCrawle: $noCrawle, preventAiLearning: $preventAiLearning, isBot: $isBot, isCat: $isCat, injectFeaturedNote: $injectFeaturedNote, receiveAnnouncementEmail: $receiveAnnouncementEmail, alwaysMarkNsfw: $alwaysMarkNsfw, ffVisibility: $ffVisibility, followingVisibility: $followingVisibility, followersVisibility: $followersVisibility, pinnedPageId: $pinnedPageId, mutingNotificationTypes: $mutingNotificationTypes, mutedWords: $mutedWords, hardMutedWords: $hardMutedWords, mutedInstances: $mutedInstances, emailNotificationTypes: $emailNotificationTypes, alsoKnownAs: $alsoKnownAs)';
+    return 'IUpdateRequest(name: $name, description: $description, location: $location, birthday: $birthday, lang: $lang, avatarId: $avatarId, avatarDecorations: $avatarDecorations, bannerId: $bannerId, fields: $fields, isLocked: $isLocked, isExplorable: $isExplorable, hideOnlineStatus: $hideOnlineStatus, publicReactions: $publicReactions, carefulBot: $carefulBot, autoAcceptFollowed: $autoAcceptFollowed, noCrawle: $noCrawle, preventAiLearning: $preventAiLearning, isBot: $isBot, isCat: $isCat, injectFeaturedNote: $injectFeaturedNote, receiveAnnouncementEmail: $receiveAnnouncementEmail, alwaysMarkNsfw: $alwaysMarkNsfw, autoSensitive: $autoSensitive, ffVisibility: $ffVisibility, followingVisibility: $followingVisibility, followersVisibility: $followersVisibility, pinnedPageId: $pinnedPageId, mutingNotificationTypes: $mutingNotificationTypes, mutedWords: $mutedWords, hardMutedWords: $hardMutedWords, mutedInstances: $mutedInstances, notificationRecieveConfig: $notificationRecieveConfig, emailNotificationTypes: $emailNotificationTypes, alsoKnownAs: $alsoKnownAs)';
   }
 
   @override
@@ -678,6 +756,8 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
             (identical(other.lang, lang) || other.lang == lang) &&
             (identical(other.avatarId, avatarId) ||
                 other.avatarId == avatarId) &&
+            const DeepCollectionEquality()
+                .equals(other._avatarDecorations, _avatarDecorations) &&
             (identical(other.bannerId, bannerId) ||
                 other.bannerId == bannerId) &&
             const DeepCollectionEquality().equals(other._fields, _fields) &&
@@ -706,6 +786,8 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
                 other.receiveAnnouncementEmail == receiveAnnouncementEmail) &&
             (identical(other.alwaysMarkNsfw, alwaysMarkNsfw) ||
                 other.alwaysMarkNsfw == alwaysMarkNsfw) &&
+            (identical(other.autoSensitive, autoSensitive) ||
+                other.autoSensitive == autoSensitive) &&
             (identical(other.ffVisibility, ffVisibility) ||
                 other.ffVisibility == ffVisibility) &&
             (identical(other.followingVisibility, followingVisibility) ||
@@ -722,6 +804,9 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
                 .equals(other._hardMutedWords, _hardMutedWords) &&
             const DeepCollectionEquality()
                 .equals(other._mutedInstances, _mutedInstances) &&
+            (identical(other.notificationRecieveConfig,
+                    notificationRecieveConfig) ||
+                other.notificationRecieveConfig == notificationRecieveConfig) &&
             const DeepCollectionEquality().equals(
                 other._emailNotificationTypes, _emailNotificationTypes) &&
             const DeepCollectionEquality()
@@ -738,6 +823,7 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
         const DeepCollectionEquality().hash(birthday),
         lang,
         avatarId,
+        const DeepCollectionEquality().hash(_avatarDecorations),
         bannerId,
         const DeepCollectionEquality().hash(_fields),
         isLocked,
@@ -753,6 +839,7 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
         injectFeaturedNote,
         receiveAnnouncementEmail,
         alwaysMarkNsfw,
+        autoSensitive,
         ffVisibility,
         followingVisibility,
         followersVisibility,
@@ -761,6 +848,7 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
         const DeepCollectionEquality().hash(_mutedWords),
         const DeepCollectionEquality().hash(_hardMutedWords),
         const DeepCollectionEquality().hash(_mutedInstances),
+        notificationRecieveConfig,
         const DeepCollectionEquality().hash(_emailNotificationTypes),
         const DeepCollectionEquality().hash(_alsoKnownAs)
       ]);
@@ -788,6 +876,7 @@ abstract class _IUpdateRequest implements IUpdateRequest {
       @DateTimeConverter() final dynamic birthday,
       final String? lang,
       final String? avatarId,
+      final List<IUpdateAvatarDecoration>? avatarDecorations,
       final String? bannerId,
       final List<UserField>? fields,
       final bool? isLocked,
@@ -803,6 +892,7 @@ abstract class _IUpdateRequest implements IUpdateRequest {
       final bool? injectFeaturedNote,
       final bool? receiveAnnouncementEmail,
       final bool? alwaysMarkNsfw,
+      final bool? autoSensitive,
       @Deprecated("removed at 2023.12.0") final FFVisibility? ffVisibility,
       final FFVisibility? followingVisibility,
       final FFVisibility? followersVisibility,
@@ -811,6 +901,7 @@ abstract class _IUpdateRequest implements IUpdateRequest {
       @MuteWordsConverter() final List<MuteWord>? mutedWords,
       @MuteWordsConverter() final List<MuteWord>? hardMutedWords,
       final List<String>? mutedInstances,
+      final NotificationRecieveConfigs? notificationRecieveConfig,
       final List<String>? emailNotificationTypes,
       final List<String>? alsoKnownAs}) = _$IUpdateRequestImpl;
 
@@ -830,6 +921,8 @@ abstract class _IUpdateRequest implements IUpdateRequest {
   String? get lang;
   @override
   String? get avatarId;
+  @override
+  List<IUpdateAvatarDecoration>? get avatarDecorations;
   @override
   String? get bannerId;
   @override
@@ -861,6 +954,8 @@ abstract class _IUpdateRequest implements IUpdateRequest {
   @override
   bool? get alwaysMarkNsfw;
   @override
+  bool? get autoSensitive;
+  @override
   @Deprecated("removed at 2023.12.0")
   FFVisibility? get ffVisibility;
   @override
@@ -880,6 +975,8 @@ abstract class _IUpdateRequest implements IUpdateRequest {
   @override
   List<String>? get mutedInstances;
   @override
+  NotificationRecieveConfigs? get notificationRecieveConfig;
+  @override
   List<String>? get emailNotificationTypes;
   @override
   List<String>? get alsoKnownAs;
@@ -887,4 +984,226 @@ abstract class _IUpdateRequest implements IUpdateRequest {
   @JsonKey(ignore: true)
   _$$IUpdateRequestImplCopyWith<_$IUpdateRequestImpl> get copyWith =>
       throw _privateConstructorUsedError;
+}
+
+IUpdateAvatarDecoration _$IUpdateAvatarDecorationFromJson(
+    Map<String, dynamic> json) {
+  return _IUpdateAvatarDecoration.fromJson(json);
+}
+
+/// @nodoc
+mixin _$IUpdateAvatarDecoration {
+  String get id => throw _privateConstructorUsedError;
+  double? get angle => throw _privateConstructorUsedError;
+  bool get flipH => throw _privateConstructorUsedError;
+  double get offsetX => throw _privateConstructorUsedError;
+  double get offsetY => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $IUpdateAvatarDecorationCopyWith<IUpdateAvatarDecoration> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $IUpdateAvatarDecorationCopyWith<$Res> {
+  factory $IUpdateAvatarDecorationCopyWith(IUpdateAvatarDecoration value,
+          $Res Function(IUpdateAvatarDecoration) then) =
+      _$IUpdateAvatarDecorationCopyWithImpl<$Res, IUpdateAvatarDecoration>;
+  @useResult
+  $Res call(
+      {String id, double? angle, bool flipH, double offsetX, double offsetY});
+}
+
+/// @nodoc
+class _$IUpdateAvatarDecorationCopyWithImpl<$Res,
+        $Val extends IUpdateAvatarDecoration>
+    implements $IUpdateAvatarDecorationCopyWith<$Res> {
+  _$IUpdateAvatarDecorationCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? angle = freezed,
+    Object? flipH = null,
+    Object? offsetX = null,
+    Object? offsetY = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      angle: freezed == angle
+          ? _value.angle
+          : angle // ignore: cast_nullable_to_non_nullable
+              as double?,
+      flipH: null == flipH
+          ? _value.flipH
+          : flipH // ignore: cast_nullable_to_non_nullable
+              as bool,
+      offsetX: null == offsetX
+          ? _value.offsetX
+          : offsetX // ignore: cast_nullable_to_non_nullable
+              as double,
+      offsetY: null == offsetY
+          ? _value.offsetY
+          : offsetY // ignore: cast_nullable_to_non_nullable
+              as double,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$IUpdateAvatarDecorationImplCopyWith<$Res>
+    implements $IUpdateAvatarDecorationCopyWith<$Res> {
+  factory _$$IUpdateAvatarDecorationImplCopyWith(
+          _$IUpdateAvatarDecorationImpl value,
+          $Res Function(_$IUpdateAvatarDecorationImpl) then) =
+      __$$IUpdateAvatarDecorationImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id, double? angle, bool flipH, double offsetX, double offsetY});
+}
+
+/// @nodoc
+class __$$IUpdateAvatarDecorationImplCopyWithImpl<$Res>
+    extends _$IUpdateAvatarDecorationCopyWithImpl<$Res,
+        _$IUpdateAvatarDecorationImpl>
+    implements _$$IUpdateAvatarDecorationImplCopyWith<$Res> {
+  __$$IUpdateAvatarDecorationImplCopyWithImpl(
+      _$IUpdateAvatarDecorationImpl _value,
+      $Res Function(_$IUpdateAvatarDecorationImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? angle = freezed,
+    Object? flipH = null,
+    Object? offsetX = null,
+    Object? offsetY = null,
+  }) {
+    return _then(_$IUpdateAvatarDecorationImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      angle: freezed == angle
+          ? _value.angle
+          : angle // ignore: cast_nullable_to_non_nullable
+              as double?,
+      flipH: null == flipH
+          ? _value.flipH
+          : flipH // ignore: cast_nullable_to_non_nullable
+              as bool,
+      offsetX: null == offsetX
+          ? _value.offsetX
+          : offsetX // ignore: cast_nullable_to_non_nullable
+              as double,
+      offsetY: null == offsetY
+          ? _value.offsetY
+          : offsetY // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$IUpdateAvatarDecorationImpl implements _IUpdateAvatarDecoration {
+  const _$IUpdateAvatarDecorationImpl(
+      {required this.id,
+      this.angle,
+      this.flipH = false,
+      this.offsetX = 0.0,
+      this.offsetY = 0.0});
+
+  factory _$IUpdateAvatarDecorationImpl.fromJson(Map<String, dynamic> json) =>
+      _$$IUpdateAvatarDecorationImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final double? angle;
+  @override
+  @JsonKey()
+  final bool flipH;
+  @override
+  @JsonKey()
+  final double offsetX;
+  @override
+  @JsonKey()
+  final double offsetY;
+
+  @override
+  String toString() {
+    return 'IUpdateAvatarDecoration(id: $id, angle: $angle, flipH: $flipH, offsetX: $offsetX, offsetY: $offsetY)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$IUpdateAvatarDecorationImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.angle, angle) || other.angle == angle) &&
+            (identical(other.flipH, flipH) || other.flipH == flipH) &&
+            (identical(other.offsetX, offsetX) || other.offsetX == offsetX) &&
+            (identical(other.offsetY, offsetY) || other.offsetY == offsetY));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, id, angle, flipH, offsetX, offsetY);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$IUpdateAvatarDecorationImplCopyWith<_$IUpdateAvatarDecorationImpl>
+      get copyWith => __$$IUpdateAvatarDecorationImplCopyWithImpl<
+          _$IUpdateAvatarDecorationImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$IUpdateAvatarDecorationImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _IUpdateAvatarDecoration implements IUpdateAvatarDecoration {
+  const factory _IUpdateAvatarDecoration(
+      {required final String id,
+      final double? angle,
+      final bool flipH,
+      final double offsetX,
+      final double offsetY}) = _$IUpdateAvatarDecorationImpl;
+
+  factory _IUpdateAvatarDecoration.fromJson(Map<String, dynamic> json) =
+      _$IUpdateAvatarDecorationImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  double? get angle;
+  @override
+  bool get flipH;
+  @override
+  double get offsetX;
+  @override
+  double get offsetY;
+  @override
+  @JsonKey(ignore: true)
+  _$$IUpdateAvatarDecorationImplCopyWith<_$IUpdateAvatarDecorationImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/data/i/i_update_request.g.dart
+++ b/lib/src/data/i/i_update_request.g.dart
@@ -14,6 +14,10 @@ _$IUpdateRequestImpl _$$IUpdateRequestImplFromJson(Map<String, dynamic> json) =>
       birthday: json['birthday'],
       lang: json['lang'] as String?,
       avatarId: json['avatarId'] as String?,
+      avatarDecorations: (json['avatarDecorations'] as List<dynamic>?)
+          ?.map((e) =>
+              IUpdateAvatarDecoration.fromJson(e as Map<String, dynamic>))
+          .toList(),
       bannerId: json['bannerId'] as String?,
       fields: (json['fields'] as List<dynamic>?)
           ?.map((e) => UserField.fromJson(e as Map<String, dynamic>))
@@ -31,6 +35,7 @@ _$IUpdateRequestImpl _$$IUpdateRequestImplFromJson(Map<String, dynamic> json) =>
       injectFeaturedNote: json['injectFeaturedNote'] as bool?,
       receiveAnnouncementEmail: json['receiveAnnouncementEmail'] as bool?,
       alwaysMarkNsfw: json['alwaysMarkNsfw'] as bool?,
+      autoSensitive: json['autoSensitive'] as bool?,
       ffVisibility:
           $enumDecodeNullable(_$FFVisibilityEnumMap, json['ffVisibility']),
       followingVisibility: $enumDecodeNullable(
@@ -51,6 +56,10 @@ _$IUpdateRequestImpl _$$IUpdateRequestImplFromJson(Map<String, dynamic> json) =>
       mutedInstances: (json['mutedInstances'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList(),
+      notificationRecieveConfig: json['notificationRecieveConfig'] == null
+          ? null
+          : NotificationRecieveConfigs.fromJson(
+              json['notificationRecieveConfig'] as Map<String, dynamic>),
       emailNotificationTypes: (json['emailNotificationTypes'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList(),
@@ -68,6 +77,8 @@ Map<String, dynamic> _$$IUpdateRequestImplToJson(
       'birthday': instance.birthday,
       'lang': instance.lang,
       'avatarId': instance.avatarId,
+      'avatarDecorations':
+          instance.avatarDecorations?.map((e) => e.toJson()).toList(),
       'bannerId': instance.bannerId,
       'fields': instance.fields?.map((e) => e.toJson()).toList(),
       'isLocked': instance.isLocked,
@@ -83,6 +94,7 @@ Map<String, dynamic> _$$IUpdateRequestImplToJson(
       'injectFeaturedNote': instance.injectFeaturedNote,
       'receiveAnnouncementEmail': instance.receiveAnnouncementEmail,
       'alwaysMarkNsfw': instance.alwaysMarkNsfw,
+      'autoSensitive': instance.autoSensitive,
       'ffVisibility': _$FFVisibilityEnumMap[instance.ffVisibility],
       'followingVisibility':
           _$FFVisibilityEnumMap[instance.followingVisibility],
@@ -96,6 +108,7 @@ Map<String, dynamic> _$$IUpdateRequestImplToJson(
           ?.map(const MuteWordsConverter().toJson)
           .toList(),
       'mutedInstances': instance.mutedInstances,
+      'notificationRecieveConfig': instance.notificationRecieveConfig?.toJson(),
       'emailNotificationTypes': instance.emailNotificationTypes,
       'alsoKnownAs': instance.alsoKnownAs,
     };
@@ -105,3 +118,23 @@ const _$FFVisibilityEnumMap = {
   FFVisibility.followers: 'followers',
   FFVisibility.private: 'private',
 };
+
+_$IUpdateAvatarDecorationImpl _$$IUpdateAvatarDecorationImplFromJson(
+        Map<String, dynamic> json) =>
+    _$IUpdateAvatarDecorationImpl(
+      id: json['id'] as String,
+      angle: (json['angle'] as num?)?.toDouble(),
+      flipH: json['flipH'] as bool? ?? false,
+      offsetX: (json['offsetX'] as num?)?.toDouble() ?? 0.0,
+      offsetY: (json['offsetY'] as num?)?.toDouble() ?? 0.0,
+    );
+
+Map<String, dynamic> _$$IUpdateAvatarDecorationImplToJson(
+        _$IUpdateAvatarDecorationImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'angle': instance.angle,
+      'flipH': instance.flipH,
+      'offsetX': instance.offsetX,
+      'offsetY': instance.offsetY,
+    };


### PR DESCRIPTION
ユーザーのフィールドのうち抜けていたものを追加しました

- `movedTo`
- `alsoKnownAs`
- `verifiedLinks`
- `moderationNote`
- `notify`
- `withReplies`
- `preventAiLearning`
- `twoFactorBackupCodesStock`

`notificationRecieveConfig`に型を付けました

`IUpdateRequest`のフィールドのうち抜けていたものを追加しました

- `avatarDecorations`
- `autoSensitive`
- `notificationRecieveConfig`