### PR TITLE
UriConverterで前後の余分な空白やタブを除去してからUriを得る

### DIFF
--- a/lib/src/converters/uri_converter.dart
+++ b/lib/src/converters/uri_converter.dart
@@ -19,7 +19,7 @@ class UriConverter extends JsonConverter<Uri, String> {
 
   @override
   Uri fromJson(String json) {
-    return Uri.parse(json);
+    return Uri.parse(json.trim());
   }
 
   @override

--- a/lib/src/data/meta_response.g.dart
+++ b/lib/src/data/meta_response.g.dart
@@ -162,7 +162,7 @@ _$MetaAdImpl _$$MetaAdImplFromJson(Map<String, dynamic> json) => _$MetaAdImpl(
       id: json['id'] as String,
       place: json['place'] as String,
       url: const UriConverter().fromJson(json['url'] as String),
-      imageUrl: const UriConverter().fromJson((json['imageUrl'] as String).trim()),
+      imageUrl: const UriConverter().fromJson(json['imageUrl'] as String),
       ratio: json['ratio'] as int,
     );
 

--- a/lib/src/data/meta_response.g.dart
+++ b/lib/src/data/meta_response.g.dart
@@ -162,7 +162,7 @@ _$MetaAdImpl _$$MetaAdImplFromJson(Map<String, dynamic> json) => _$MetaAdImpl(
       id: json['id'] as String,
       place: json['place'] as String,
       url: const UriConverter().fromJson(json['url'] as String),
-      imageUrl: const UriConverter().fromJson(json['imageUrl'] as String),
+      imageUrl: const UriConverter().fromJson((json['imageUrl'] as String).trim()),
       ratio: json['ratio'] as int,
     );
 


### PR DESCRIPTION
MetaResponseをサーバからのレスポンスで構成する際に、adsのimageUrlの先頭にタブ文字が入っているサーバがあり、接続時に例外が発生しましたので、trimでタブ文字を除去する対応を加えたものです。  
ええ、このケースは、サーバ側の問題だと思います。  
クライアント側で処置することが不適当と感じたなら、拒否していただいて良いと思います。

[問題発見時の記録](https://github.com/darlington95/reading_miria/wiki/%E3%83%87%E3%83%90%E3%83%83%E3%82%AC%E3%81%A7%E8%BF%BD%E3%81%84%E3%81%BE%E3%81%97%E3%81%A6#ads%E3%81%AEimageUrl%E3%81%AE%E5%85%88%E9%A0%AD%E3%81%AB%E3%82%BF%E3%83%96%E6%96%87%E5%AD%97%E3%81%8C%E3%81%82%E3%82%8B)