### PR TITLE
ノートの非表示に対応

### DIFF
--- a/lib/src/converters/hide_before_converter.dart
+++ b/lib/src/converters/hide_before_converter.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:misskey_dart/misskey_dart.dart';
+
+class HideBeforeConverter extends JsonConverter<HideBefore, int> {
+  const HideBeforeConverter();
+
+  @override
+  HideBefore fromJson(int json) {
+    if (json <= 0) {
+      return HideBeforeDuration(Duration(seconds: json));
+    } else {
+      return HideBeforeDateTime(
+        DateTime.fromMillisecondsSinceEpoch(json * 1000),
+      );
+    }
+  }
+
+  @override
+  int toJson(HideBefore object) => switch (object) {
+        HideBeforeDuration(:final duration) => duration.inSeconds,
+        HideBeforeDateTime(:final date) => date.millisecondsSinceEpoch ~/ 1000,
+      };
+}

--- a/lib/src/data/base/user.dart
+++ b/lib/src/data/base/user.dart
@@ -2,6 +2,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 import 'package:misskey_dart/src/converters/date_time_converter.dart';
 import 'package:misskey_dart/src/converters/emojis_converter.dart';
+import 'package:misskey_dart/src/converters/hide_before_converter.dart';
 import 'package:misskey_dart/src/converters/mute_words_converter.dart';
 import 'package:misskey_dart/src/converters/uri_converter.dart';
 
@@ -22,6 +23,9 @@ abstract class User {
   bool get isCat;
   bool get isBot;
   Map<String, String> get emojis;
+  bool? get requireSigninToViewContents;
+  HideBefore? get makeNotesFollowersOnlyBefore;
+  HideBefore? get makeNotesHiddenBefore;
 
   factory User.fromJson(Map<String, Object?> json) {
     if (json.containsKey("url")) {
@@ -106,6 +110,9 @@ class UserLite with _$UserLite implements User {
     @EmojisConverter() @Default({}) Map<String, String> emojis,
     @OnlineStatusJsonConverter() OnlineStatus? onlineStatus,
     @Default([]) List<UserBadgeRole> badgeRoles,
+    bool? requireSigninToViewContents,
+    @HideBeforeConverter() HideBefore? makeNotesFollowersOnlyBefore,
+    @HideBeforeConverter() HideBefore? makeNotesHiddenBefore,
   }) = _UserLite;
 
   factory UserLite.fromJson(Map<String, Object?> json) =>
@@ -128,6 +135,9 @@ class UserDetailedNotMe with _$UserDetailedNotMe implements UserDetailed {
     @EmojisConverter() @Default({}) Map<String, String> emojis,
     @OnlineStatusJsonConverter() OnlineStatus? onlineStatus,
     @Default([]) List<UserBadgeRole> badgeRoles,
+    bool? requireSigninToViewContents,
+    @HideBeforeConverter() HideBefore? makeNotesFollowersOnlyBefore,
+    @HideBeforeConverter() HideBefore? makeNotesHiddenBefore,
     @NullableUriConverter() Uri? url,
     @NullableUriConverter() Uri? uri,
     @NullableUriConverter() Uri? movedTo,
@@ -187,6 +197,9 @@ class UserDetailedNotMeWithRelations
     @EmojisConverter() @Default({}) Map<String, String> emojis,
     @OnlineStatusJsonConverter() OnlineStatus? onlineStatus,
     @Default([]) List<UserBadgeRole> badgeRoles,
+    bool? requireSigninToViewContents,
+    @HideBeforeConverter() HideBefore? makeNotesFollowersOnlyBefore,
+    @HideBeforeConverter() HideBefore? makeNotesHiddenBefore,
     @NullableUriConverter() Uri? url,
     @NullableUriConverter() Uri? uri,
     @NullableUriConverter() Uri? movedTo,
@@ -255,6 +268,9 @@ class MeDetailed with _$MeDetailed implements UserDetailed {
     @EmojisConverter() @Default({}) Map<String, String> emojis,
     @OnlineStatusJsonConverter() OnlineStatus? onlineStatus,
     @Default([]) List<UserBadgeRole> badgeRoles,
+    bool? requireSigninToViewContents,
+    @HideBeforeConverter() HideBefore? makeNotesFollowersOnlyBefore,
+    @HideBeforeConverter() HideBefore? makeNotesHiddenBefore,
     @NullableUriConverter() Uri? url,
     @NullableUriConverter() Uri? uri,
     @NullableUriConverter() Uri? movedTo,
@@ -371,6 +387,20 @@ class UserBadgeRole with _$UserBadgeRole {
   }) = _UserBadgeRole;
   factory UserBadgeRole.fromJson(Map<String, Object?> json) =>
       _$UserBadgeRoleFromJson(json);
+}
+
+sealed class HideBefore {}
+
+class HideBeforeDuration implements HideBefore {
+  const HideBeforeDuration(this.duration);
+
+  final Duration duration;
+}
+
+class HideBeforeDateTime implements HideBefore {
+  const HideBeforeDateTime(this.date);
+
+  final DateTime date;
 }
 
 @freezed

--- a/lib/src/data/base/user.freezed.dart
+++ b/lib/src/data/base/user.freezed.dart
@@ -37,6 +37,12 @@ mixin _$UserLite {
   @OnlineStatusJsonConverter()
   OnlineStatus? get onlineStatus => throw _privateConstructorUsedError;
   List<UserBadgeRole> get badgeRoles => throw _privateConstructorUsedError;
+  bool? get requireSigninToViewContents => throw _privateConstructorUsedError;
+  @HideBeforeConverter()
+  HideBefore? get makeNotesFollowersOnlyBefore =>
+      throw _privateConstructorUsedError;
+  @HideBeforeConverter()
+  HideBefore? get makeNotesHiddenBefore => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -62,7 +68,10 @@ abstract class $UserLiteCopyWith<$Res> {
       UserInstanceInfo? instance,
       @EmojisConverter() Map<String, String> emojis,
       @OnlineStatusJsonConverter() OnlineStatus? onlineStatus,
-      List<UserBadgeRole> badgeRoles});
+      List<UserBadgeRole> badgeRoles,
+      bool? requireSigninToViewContents,
+      @HideBeforeConverter() HideBefore? makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() HideBefore? makeNotesHiddenBefore});
 
   $UserInstanceInfoCopyWith<$Res>? get instance;
 }
@@ -93,6 +102,9 @@ class _$UserLiteCopyWithImpl<$Res, $Val extends UserLite>
     Object? emojis = null,
     Object? onlineStatus = freezed,
     Object? badgeRoles = null,
+    Object? requireSigninToViewContents = freezed,
+    Object? makeNotesFollowersOnlyBefore = freezed,
+    Object? makeNotesHiddenBefore = freezed,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -147,6 +159,18 @@ class _$UserLiteCopyWithImpl<$Res, $Val extends UserLite>
           ? _value.badgeRoles
           : badgeRoles // ignore: cast_nullable_to_non_nullable
               as List<UserBadgeRole>,
+      requireSigninToViewContents: freezed == requireSigninToViewContents
+          ? _value.requireSigninToViewContents
+          : requireSigninToViewContents // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      makeNotesFollowersOnlyBefore: freezed == makeNotesFollowersOnlyBefore
+          ? _value.makeNotesFollowersOnlyBefore
+          : makeNotesFollowersOnlyBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
+      makeNotesHiddenBefore: freezed == makeNotesHiddenBefore
+          ? _value.makeNotesHiddenBefore
+          : makeNotesHiddenBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
     ) as $Val);
   }
 
@@ -184,7 +208,10 @@ abstract class _$$UserLiteImplCopyWith<$Res>
       UserInstanceInfo? instance,
       @EmojisConverter() Map<String, String> emojis,
       @OnlineStatusJsonConverter() OnlineStatus? onlineStatus,
-      List<UserBadgeRole> badgeRoles});
+      List<UserBadgeRole> badgeRoles,
+      bool? requireSigninToViewContents,
+      @HideBeforeConverter() HideBefore? makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() HideBefore? makeNotesHiddenBefore});
 
   @override
   $UserInstanceInfoCopyWith<$Res>? get instance;
@@ -214,6 +241,9 @@ class __$$UserLiteImplCopyWithImpl<$Res>
     Object? emojis = null,
     Object? onlineStatus = freezed,
     Object? badgeRoles = null,
+    Object? requireSigninToViewContents = freezed,
+    Object? makeNotesFollowersOnlyBefore = freezed,
+    Object? makeNotesHiddenBefore = freezed,
   }) {
     return _then(_$UserLiteImpl(
       id: null == id
@@ -268,6 +298,18 @@ class __$$UserLiteImplCopyWithImpl<$Res>
           ? _value._badgeRoles
           : badgeRoles // ignore: cast_nullable_to_non_nullable
               as List<UserBadgeRole>,
+      requireSigninToViewContents: freezed == requireSigninToViewContents
+          ? _value.requireSigninToViewContents
+          : requireSigninToViewContents // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      makeNotesFollowersOnlyBefore: freezed == makeNotesFollowersOnlyBefore
+          ? _value.makeNotesFollowersOnlyBefore
+          : makeNotesFollowersOnlyBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
+      makeNotesHiddenBefore: freezed == makeNotesHiddenBefore
+          ? _value.makeNotesHiddenBefore
+          : makeNotesHiddenBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
     ));
   }
 }
@@ -288,7 +330,10 @@ class _$UserLiteImpl implements _UserLite {
       this.instance,
       @EmojisConverter() final Map<String, String> emojis = const {},
       @OnlineStatusJsonConverter() this.onlineStatus,
-      final List<UserBadgeRole> badgeRoles = const []})
+      final List<UserBadgeRole> badgeRoles = const [],
+      this.requireSigninToViewContents,
+      @HideBeforeConverter() this.makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() this.makeNotesHiddenBefore})
       : _avatarDecorations = avatarDecorations,
         _emojis = emojis,
         _badgeRoles = badgeRoles;
@@ -350,8 +395,17 @@ class _$UserLiteImpl implements _UserLite {
   }
 
   @override
+  final bool? requireSigninToViewContents;
+  @override
+  @HideBeforeConverter()
+  final HideBefore? makeNotesFollowersOnlyBefore;
+  @override
+  @HideBeforeConverter()
+  final HideBefore? makeNotesHiddenBefore;
+
+  @override
   String toString() {
-    return 'UserLite(id: $id, name: $name, username: $username, host: $host, avatarUrl: $avatarUrl, avatarBlurhash: $avatarBlurhash, avatarDecorations: $avatarDecorations, isBot: $isBot, isCat: $isCat, instance: $instance, emojis: $emojis, onlineStatus: $onlineStatus, badgeRoles: $badgeRoles)';
+    return 'UserLite(id: $id, name: $name, username: $username, host: $host, avatarUrl: $avatarUrl, avatarBlurhash: $avatarBlurhash, avatarDecorations: $avatarDecorations, isBot: $isBot, isCat: $isCat, instance: $instance, emojis: $emojis, onlineStatus: $onlineStatus, badgeRoles: $badgeRoles, requireSigninToViewContents: $requireSigninToViewContents, makeNotesFollowersOnlyBefore: $makeNotesFollowersOnlyBefore, makeNotesHiddenBefore: $makeNotesHiddenBefore)';
   }
 
   @override
@@ -378,7 +432,17 @@ class _$UserLiteImpl implements _UserLite {
             (identical(other.onlineStatus, onlineStatus) ||
                 other.onlineStatus == onlineStatus) &&
             const DeepCollectionEquality()
-                .equals(other._badgeRoles, _badgeRoles));
+                .equals(other._badgeRoles, _badgeRoles) &&
+            (identical(other.requireSigninToViewContents,
+                    requireSigninToViewContents) ||
+                other.requireSigninToViewContents ==
+                    requireSigninToViewContents) &&
+            (identical(other.makeNotesFollowersOnlyBefore,
+                    makeNotesFollowersOnlyBefore) ||
+                other.makeNotesFollowersOnlyBefore ==
+                    makeNotesFollowersOnlyBefore) &&
+            (identical(other.makeNotesHiddenBefore, makeNotesHiddenBefore) ||
+                other.makeNotesHiddenBefore == makeNotesHiddenBefore));
   }
 
   @JsonKey(ignore: true)
@@ -397,7 +461,10 @@ class _$UserLiteImpl implements _UserLite {
       instance,
       const DeepCollectionEquality().hash(_emojis),
       onlineStatus,
-      const DeepCollectionEquality().hash(_badgeRoles));
+      const DeepCollectionEquality().hash(_badgeRoles),
+      requireSigninToViewContents,
+      makeNotesFollowersOnlyBefore,
+      makeNotesHiddenBefore);
 
   @JsonKey(ignore: true)
   @override
@@ -415,19 +482,23 @@ class _$UserLiteImpl implements _UserLite {
 
 abstract class _UserLite implements UserLite {
   const factory _UserLite(
-      {required final String id,
-      final String? name,
-      required final String username,
-      final String? host,
-      @UriConverter() required final Uri avatarUrl,
-      final String? avatarBlurhash,
-      final List<UserAvatarDecoration> avatarDecorations,
-      final bool isBot,
-      final bool isCat,
-      final UserInstanceInfo? instance,
-      @EmojisConverter() final Map<String, String> emojis,
-      @OnlineStatusJsonConverter() final OnlineStatus? onlineStatus,
-      final List<UserBadgeRole> badgeRoles}) = _$UserLiteImpl;
+          {required final String id,
+          final String? name,
+          required final String username,
+          final String? host,
+          @UriConverter() required final Uri avatarUrl,
+          final String? avatarBlurhash,
+          final List<UserAvatarDecoration> avatarDecorations,
+          final bool isBot,
+          final bool isCat,
+          final UserInstanceInfo? instance,
+          @EmojisConverter() final Map<String, String> emojis,
+          @OnlineStatusJsonConverter() final OnlineStatus? onlineStatus,
+          final List<UserBadgeRole> badgeRoles,
+          final bool? requireSigninToViewContents,
+          @HideBeforeConverter() final HideBefore? makeNotesFollowersOnlyBefore,
+          @HideBeforeConverter() final HideBefore? makeNotesHiddenBefore}) =
+      _$UserLiteImpl;
 
   factory _UserLite.fromJson(Map<String, dynamic> json) =
       _$UserLiteImpl.fromJson;
@@ -462,6 +533,14 @@ abstract class _UserLite implements UserLite {
   @override
   List<UserBadgeRole> get badgeRoles;
   @override
+  bool? get requireSigninToViewContents;
+  @override
+  @HideBeforeConverter()
+  HideBefore? get makeNotesFollowersOnlyBefore;
+  @override
+  @HideBeforeConverter()
+  HideBefore? get makeNotesHiddenBefore;
+  @override
   @JsonKey(ignore: true)
   _$$UserLiteImplCopyWith<_$UserLiteImpl> get copyWith =>
       throw _privateConstructorUsedError;
@@ -490,6 +569,12 @@ mixin _$UserDetailedNotMe {
   @OnlineStatusJsonConverter()
   OnlineStatus? get onlineStatus => throw _privateConstructorUsedError;
   List<UserBadgeRole> get badgeRoles => throw _privateConstructorUsedError;
+  bool? get requireSigninToViewContents => throw _privateConstructorUsedError;
+  @HideBeforeConverter()
+  HideBefore? get makeNotesFollowersOnlyBefore =>
+      throw _privateConstructorUsedError;
+  @HideBeforeConverter()
+  HideBefore? get makeNotesHiddenBefore => throw _privateConstructorUsedError;
   @NullableUriConverter()
   Uri? get url => throw _privateConstructorUsedError;
   @NullableUriConverter()
@@ -561,6 +646,9 @@ abstract class $UserDetailedNotMeCopyWith<$Res> {
       @EmojisConverter() Map<String, String> emojis,
       @OnlineStatusJsonConverter() OnlineStatus? onlineStatus,
       List<UserBadgeRole> badgeRoles,
+      bool? requireSigninToViewContents,
+      @HideBeforeConverter() HideBefore? makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() HideBefore? makeNotesHiddenBefore,
       @NullableUriConverter() Uri? url,
       @NullableUriConverter() Uri? uri,
       @NullableUriConverter() Uri? movedTo,
@@ -626,6 +714,9 @@ class _$UserDetailedNotMeCopyWithImpl<$Res, $Val extends UserDetailedNotMe>
     Object? emojis = null,
     Object? onlineStatus = freezed,
     Object? badgeRoles = null,
+    Object? requireSigninToViewContents = freezed,
+    Object? makeNotesFollowersOnlyBefore = freezed,
+    Object? makeNotesHiddenBefore = freezed,
     Object? url = freezed,
     Object? uri = freezed,
     Object? movedTo = freezed,
@@ -715,6 +806,18 @@ class _$UserDetailedNotMeCopyWithImpl<$Res, $Val extends UserDetailedNotMe>
           ? _value.badgeRoles
           : badgeRoles // ignore: cast_nullable_to_non_nullable
               as List<UserBadgeRole>,
+      requireSigninToViewContents: freezed == requireSigninToViewContents
+          ? _value.requireSigninToViewContents
+          : requireSigninToViewContents // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      makeNotesFollowersOnlyBefore: freezed == makeNotesFollowersOnlyBefore
+          ? _value.makeNotesFollowersOnlyBefore
+          : makeNotesFollowersOnlyBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
+      makeNotesHiddenBefore: freezed == makeNotesHiddenBefore
+          ? _value.makeNotesHiddenBefore
+          : makeNotesHiddenBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
       url: freezed == url
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
@@ -893,6 +996,9 @@ abstract class _$$UserDetailedNotMeImplCopyWith<$Res>
       @EmojisConverter() Map<String, String> emojis,
       @OnlineStatusJsonConverter() OnlineStatus? onlineStatus,
       List<UserBadgeRole> badgeRoles,
+      bool? requireSigninToViewContents,
+      @HideBeforeConverter() HideBefore? makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() HideBefore? makeNotesHiddenBefore,
       @NullableUriConverter() Uri? url,
       @NullableUriConverter() Uri? uri,
       @NullableUriConverter() Uri? movedTo,
@@ -957,6 +1063,9 @@ class __$$UserDetailedNotMeImplCopyWithImpl<$Res>
     Object? emojis = null,
     Object? onlineStatus = freezed,
     Object? badgeRoles = null,
+    Object? requireSigninToViewContents = freezed,
+    Object? makeNotesFollowersOnlyBefore = freezed,
+    Object? makeNotesHiddenBefore = freezed,
     Object? url = freezed,
     Object? uri = freezed,
     Object? movedTo = freezed,
@@ -1046,6 +1155,18 @@ class __$$UserDetailedNotMeImplCopyWithImpl<$Res>
           ? _value._badgeRoles
           : badgeRoles // ignore: cast_nullable_to_non_nullable
               as List<UserBadgeRole>,
+      requireSigninToViewContents: freezed == requireSigninToViewContents
+          ? _value.requireSigninToViewContents
+          : requireSigninToViewContents // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      makeNotesFollowersOnlyBefore: freezed == makeNotesFollowersOnlyBefore
+          ? _value.makeNotesFollowersOnlyBefore
+          : makeNotesFollowersOnlyBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
+      makeNotesHiddenBefore: freezed == makeNotesHiddenBefore
+          ? _value.makeNotesHiddenBefore
+          : makeNotesHiddenBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
       url: freezed == url
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
@@ -1207,6 +1328,9 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
       @EmojisConverter() final Map<String, String> emojis = const {},
       @OnlineStatusJsonConverter() this.onlineStatus,
       final List<UserBadgeRole> badgeRoles = const [],
+      this.requireSigninToViewContents,
+      @HideBeforeConverter() this.makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() this.makeNotesHiddenBefore,
       @NullableUriConverter() this.url,
       @NullableUriConverter() this.uri,
       @NullableUriConverter() this.movedTo,
@@ -1307,6 +1431,14 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
     return EqualUnmodifiableListView(_badgeRoles);
   }
 
+  @override
+  final bool? requireSigninToViewContents;
+  @override
+  @HideBeforeConverter()
+  final HideBefore? makeNotesFollowersOnlyBefore;
+  @override
+  @HideBeforeConverter()
+  final HideBefore? makeNotesHiddenBefore;
   @override
   @NullableUriConverter()
   final Uri? url;
@@ -1444,7 +1576,7 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
 
   @override
   String toString() {
-    return 'UserDetailedNotMe(id: $id, name: $name, username: $username, host: $host, avatarUrl: $avatarUrl, avatarBlurhash: $avatarBlurhash, avatarDecorations: $avatarDecorations, isBot: $isBot, isCat: $isCat, instance: $instance, emojis: $emojis, onlineStatus: $onlineStatus, badgeRoles: $badgeRoles, url: $url, uri: $uri, movedTo: $movedTo, alsoKnownAs: $alsoKnownAs, createdAt: $createdAt, updatedAt: $updatedAt, lastFetchedAt: $lastFetchedAt, bannerUrl: $bannerUrl, bannerBlurhash: $bannerBlurhash, isLocked: $isLocked, isSilenced: $isSilenced, isSuspended: $isSuspended, description: $description, location: $location, birthday: $birthday, lang: $lang, fields: $fields, verifiedLinks: $verifiedLinks, followersCount: $followersCount, followingCount: $followingCount, notesCount: $notesCount, pinnedNoteIds: $pinnedNoteIds, pinnedNotes: $pinnedNotes, pinnedPageId: $pinnedPageId, pinnedPage: $pinnedPage, publicReactions: $publicReactions, ffVisibility: $ffVisibility, followersVisibility: $followersVisibility, followingVisibility: $followingVisibility, twoFactorEnabled: $twoFactorEnabled, usePasswordLessLogin: $usePasswordLessLogin, securityKeys: $securityKeys, roles: $roles, memo: $memo, moderationNote: $moderationNote)';
+    return 'UserDetailedNotMe(id: $id, name: $name, username: $username, host: $host, avatarUrl: $avatarUrl, avatarBlurhash: $avatarBlurhash, avatarDecorations: $avatarDecorations, isBot: $isBot, isCat: $isCat, instance: $instance, emojis: $emojis, onlineStatus: $onlineStatus, badgeRoles: $badgeRoles, requireSigninToViewContents: $requireSigninToViewContents, makeNotesFollowersOnlyBefore: $makeNotesFollowersOnlyBefore, makeNotesHiddenBefore: $makeNotesHiddenBefore, url: $url, uri: $uri, movedTo: $movedTo, alsoKnownAs: $alsoKnownAs, createdAt: $createdAt, updatedAt: $updatedAt, lastFetchedAt: $lastFetchedAt, bannerUrl: $bannerUrl, bannerBlurhash: $bannerBlurhash, isLocked: $isLocked, isSilenced: $isSilenced, isSuspended: $isSuspended, description: $description, location: $location, birthday: $birthday, lang: $lang, fields: $fields, verifiedLinks: $verifiedLinks, followersCount: $followersCount, followingCount: $followingCount, notesCount: $notesCount, pinnedNoteIds: $pinnedNoteIds, pinnedNotes: $pinnedNotes, pinnedPageId: $pinnedPageId, pinnedPage: $pinnedPage, publicReactions: $publicReactions, ffVisibility: $ffVisibility, followersVisibility: $followersVisibility, followingVisibility: $followingVisibility, twoFactorEnabled: $twoFactorEnabled, usePasswordLessLogin: $usePasswordLessLogin, securityKeys: $securityKeys, roles: $roles, memo: $memo, moderationNote: $moderationNote)';
   }
 
   @override
@@ -1472,6 +1604,14 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
                 other.onlineStatus == onlineStatus) &&
             const DeepCollectionEquality()
                 .equals(other._badgeRoles, _badgeRoles) &&
+            (identical(other.requireSigninToViewContents, requireSigninToViewContents) ||
+                other.requireSigninToViewContents ==
+                    requireSigninToViewContents) &&
+            (identical(other.makeNotesFollowersOnlyBefore, makeNotesFollowersOnlyBefore) ||
+                other.makeNotesFollowersOnlyBefore ==
+                    makeNotesFollowersOnlyBefore) &&
+            (identical(other.makeNotesHiddenBefore, makeNotesHiddenBefore) ||
+                other.makeNotesHiddenBefore == makeNotesHiddenBefore) &&
             (identical(other.url, url) || other.url == url) &&
             (identical(other.uri, uri) || other.uri == uri) &&
             (identical(other.movedTo, movedTo) || other.movedTo == movedTo) &&
@@ -1513,28 +1653,18 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
                 .equals(other._pinnedNoteIds, _pinnedNoteIds) &&
             const DeepCollectionEquality()
                 .equals(other._pinnedNotes, _pinnedNotes) &&
-            (identical(other.pinnedPageId, pinnedPageId) ||
-                other.pinnedPageId == pinnedPageId) &&
-            const DeepCollectionEquality()
-                .equals(other._pinnedPage, _pinnedPage) &&
-            (identical(other.publicReactions, publicReactions) ||
-                other.publicReactions == publicReactions) &&
-            (identical(other.ffVisibility, ffVisibility) ||
-                other.ffVisibility == ffVisibility) &&
-            (identical(other.followersVisibility, followersVisibility) ||
-                other.followersVisibility == followersVisibility) &&
-            (identical(other.followingVisibility, followingVisibility) ||
-                other.followingVisibility == followingVisibility) &&
-            (identical(other.twoFactorEnabled, twoFactorEnabled) ||
-                other.twoFactorEnabled == twoFactorEnabled) &&
-            (identical(other.usePasswordLessLogin, usePasswordLessLogin) ||
-                other.usePasswordLessLogin == usePasswordLessLogin) &&
-            (identical(other.securityKeys, securityKeys) ||
-                other.securityKeys == securityKeys) &&
+            (identical(other.pinnedPageId, pinnedPageId) || other.pinnedPageId == pinnedPageId) &&
+            const DeepCollectionEquality().equals(other._pinnedPage, _pinnedPage) &&
+            (identical(other.publicReactions, publicReactions) || other.publicReactions == publicReactions) &&
+            (identical(other.ffVisibility, ffVisibility) || other.ffVisibility == ffVisibility) &&
+            (identical(other.followersVisibility, followersVisibility) || other.followersVisibility == followersVisibility) &&
+            (identical(other.followingVisibility, followingVisibility) || other.followingVisibility == followingVisibility) &&
+            (identical(other.twoFactorEnabled, twoFactorEnabled) || other.twoFactorEnabled == twoFactorEnabled) &&
+            (identical(other.usePasswordLessLogin, usePasswordLessLogin) || other.usePasswordLessLogin == usePasswordLessLogin) &&
+            (identical(other.securityKeys, securityKeys) || other.securityKeys == securityKeys) &&
             const DeepCollectionEquality().equals(other._roles, _roles) &&
             (identical(other.memo, memo) || other.memo == memo) &&
-            (identical(other.moderationNote, moderationNote) ||
-                other.moderationNote == moderationNote));
+            (identical(other.moderationNote, moderationNote) || other.moderationNote == moderationNote));
   }
 
   @JsonKey(ignore: true)
@@ -1554,6 +1684,9 @@ class _$UserDetailedNotMeImpl implements _UserDetailedNotMe {
         const DeepCollectionEquality().hash(_emojis),
         onlineStatus,
         const DeepCollectionEquality().hash(_badgeRoles),
+        requireSigninToViewContents,
+        makeNotesFollowersOnlyBefore,
+        makeNotesHiddenBefore,
         url,
         uri,
         movedTo,
@@ -1621,6 +1754,9 @@ abstract class _UserDetailedNotMe implements UserDetailedNotMe {
       @EmojisConverter() final Map<String, String> emojis,
       @OnlineStatusJsonConverter() final OnlineStatus? onlineStatus,
       final List<UserBadgeRole> badgeRoles,
+      final bool? requireSigninToViewContents,
+      @HideBeforeConverter() final HideBefore? makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() final HideBefore? makeNotesHiddenBefore,
       @NullableUriConverter() final Uri? url,
       @NullableUriConverter() final Uri? uri,
       @NullableUriConverter() final Uri? movedTo,
@@ -1689,6 +1825,14 @@ abstract class _UserDetailedNotMe implements UserDetailedNotMe {
   OnlineStatus? get onlineStatus;
   @override
   List<UserBadgeRole> get badgeRoles;
+  @override
+  bool? get requireSigninToViewContents;
+  @override
+  @HideBeforeConverter()
+  HideBefore? get makeNotesFollowersOnlyBefore;
+  @override
+  @HideBeforeConverter()
+  HideBefore? get makeNotesHiddenBefore;
   @override
   @NullableUriConverter()
   Uri? get url;
@@ -1798,6 +1942,12 @@ mixin _$UserDetailedNotMeWithRelations {
   @OnlineStatusJsonConverter()
   OnlineStatus? get onlineStatus => throw _privateConstructorUsedError;
   List<UserBadgeRole> get badgeRoles => throw _privateConstructorUsedError;
+  bool? get requireSigninToViewContents => throw _privateConstructorUsedError;
+  @HideBeforeConverter()
+  HideBefore? get makeNotesFollowersOnlyBefore =>
+      throw _privateConstructorUsedError;
+  @HideBeforeConverter()
+  HideBefore? get makeNotesHiddenBefore => throw _privateConstructorUsedError;
   @NullableUriConverter()
   Uri? get url => throw _privateConstructorUsedError;
   @NullableUriConverter()
@@ -1882,6 +2032,9 @@ abstract class $UserDetailedNotMeWithRelationsCopyWith<$Res> {
       @EmojisConverter() Map<String, String> emojis,
       @OnlineStatusJsonConverter() OnlineStatus? onlineStatus,
       List<UserBadgeRole> badgeRoles,
+      bool? requireSigninToViewContents,
+      @HideBeforeConverter() HideBefore? makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() HideBefore? makeNotesHiddenBefore,
       @NullableUriConverter() Uri? url,
       @NullableUriConverter() Uri? uri,
       @NullableUriConverter() Uri? movedTo,
@@ -1959,6 +2112,9 @@ class _$UserDetailedNotMeWithRelationsCopyWithImpl<$Res,
     Object? emojis = null,
     Object? onlineStatus = freezed,
     Object? badgeRoles = null,
+    Object? requireSigninToViewContents = freezed,
+    Object? makeNotesFollowersOnlyBefore = freezed,
+    Object? makeNotesHiddenBefore = freezed,
     Object? url = freezed,
     Object? uri = freezed,
     Object? movedTo = freezed,
@@ -2059,6 +2215,18 @@ class _$UserDetailedNotMeWithRelationsCopyWithImpl<$Res,
           ? _value.badgeRoles
           : badgeRoles // ignore: cast_nullable_to_non_nullable
               as List<UserBadgeRole>,
+      requireSigninToViewContents: freezed == requireSigninToViewContents
+          ? _value.requireSigninToViewContents
+          : requireSigninToViewContents // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      makeNotesFollowersOnlyBefore: freezed == makeNotesFollowersOnlyBefore
+          ? _value.makeNotesFollowersOnlyBefore
+          : makeNotesFollowersOnlyBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
+      makeNotesHiddenBefore: freezed == makeNotesHiddenBefore
+          ? _value.makeNotesHiddenBefore
+          : makeNotesHiddenBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
       url: freezed == url
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
@@ -2282,6 +2450,9 @@ abstract class _$$UserDetailedNotMeWithRelationsImplCopyWith<$Res>
       @EmojisConverter() Map<String, String> emojis,
       @OnlineStatusJsonConverter() OnlineStatus? onlineStatus,
       List<UserBadgeRole> badgeRoles,
+      bool? requireSigninToViewContents,
+      @HideBeforeConverter() HideBefore? makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() HideBefore? makeNotesHiddenBefore,
       @NullableUriConverter() Uri? url,
       @NullableUriConverter() Uri? uri,
       @NullableUriConverter() Uri? movedTo,
@@ -2359,6 +2530,9 @@ class __$$UserDetailedNotMeWithRelationsImplCopyWithImpl<$Res>
     Object? emojis = null,
     Object? onlineStatus = freezed,
     Object? badgeRoles = null,
+    Object? requireSigninToViewContents = freezed,
+    Object? makeNotesFollowersOnlyBefore = freezed,
+    Object? makeNotesHiddenBefore = freezed,
     Object? url = freezed,
     Object? uri = freezed,
     Object? movedTo = freezed,
@@ -2459,6 +2633,18 @@ class __$$UserDetailedNotMeWithRelationsImplCopyWithImpl<$Res>
           ? _value._badgeRoles
           : badgeRoles // ignore: cast_nullable_to_non_nullable
               as List<UserBadgeRole>,
+      requireSigninToViewContents: freezed == requireSigninToViewContents
+          ? _value.requireSigninToViewContents
+          : requireSigninToViewContents // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      makeNotesFollowersOnlyBefore: freezed == makeNotesFollowersOnlyBefore
+          ? _value.makeNotesFollowersOnlyBefore
+          : makeNotesFollowersOnlyBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
+      makeNotesHiddenBefore: freezed == makeNotesHiddenBefore
+          ? _value.makeNotesHiddenBefore
+          : makeNotesHiddenBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
       url: freezed == url
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
@@ -2665,6 +2851,9 @@ class _$UserDetailedNotMeWithRelationsImpl
       @EmojisConverter() final Map<String, String> emojis = const {},
       @OnlineStatusJsonConverter() this.onlineStatus,
       final List<UserBadgeRole> badgeRoles = const [],
+      this.requireSigninToViewContents,
+      @HideBeforeConverter() this.makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() this.makeNotesHiddenBefore,
       @NullableUriConverter() this.url,
       @NullableUriConverter() this.uri,
       @NullableUriConverter() this.movedTo,
@@ -2777,6 +2966,14 @@ class _$UserDetailedNotMeWithRelationsImpl
     return EqualUnmodifiableListView(_badgeRoles);
   }
 
+  @override
+  final bool? requireSigninToViewContents;
+  @override
+  @HideBeforeConverter()
+  final HideBefore? makeNotesFollowersOnlyBefore;
+  @override
+  @HideBeforeConverter()
+  final HideBefore? makeNotesHiddenBefore;
   @override
   @NullableUriConverter()
   final Uri? url;
@@ -2936,7 +3133,7 @@ class _$UserDetailedNotMeWithRelationsImpl
 
   @override
   String toString() {
-    return 'UserDetailedNotMeWithRelations(id: $id, name: $name, username: $username, host: $host, avatarUrl: $avatarUrl, avatarBlurhash: $avatarBlurhash, avatarDecorations: $avatarDecorations, isBot: $isBot, isCat: $isCat, instance: $instance, emojis: $emojis, onlineStatus: $onlineStatus, badgeRoles: $badgeRoles, url: $url, uri: $uri, movedTo: $movedTo, alsoKnownAs: $alsoKnownAs, createdAt: $createdAt, updatedAt: $updatedAt, lastFetchedAt: $lastFetchedAt, bannerUrl: $bannerUrl, bannerBlurhash: $bannerBlurhash, isLocked: $isLocked, isSilenced: $isSilenced, isSuspended: $isSuspended, description: $description, location: $location, birthday: $birthday, lang: $lang, fields: $fields, verifiedLinks: $verifiedLinks, followersCount: $followersCount, followingCount: $followingCount, notesCount: $notesCount, pinnedNoteIds: $pinnedNoteIds, pinnedNotes: $pinnedNotes, pinnedPageId: $pinnedPageId, pinnedPage: $pinnedPage, publicReactions: $publicReactions, ffVisibility: $ffVisibility, followersVisibility: $followersVisibility, followingVisibility: $followingVisibility, twoFactorEnabled: $twoFactorEnabled, usePasswordLessLogin: $usePasswordLessLogin, securityKeys: $securityKeys, roles: $roles, memo: $memo, moderationNote: $moderationNote, isFollowing: $isFollowing, isFollowed: $isFollowed, hasPendingFollowRequestFromYou: $hasPendingFollowRequestFromYou, hasPendingFollowRequestToYou: $hasPendingFollowRequestToYou, isBlocking: $isBlocking, isBlocked: $isBlocked, isMuted: $isMuted, isRenoteMuted: $isRenoteMuted, notify: $notify, withReplies: $withReplies, followedMessage: $followedMessage)';
+    return 'UserDetailedNotMeWithRelations(id: $id, name: $name, username: $username, host: $host, avatarUrl: $avatarUrl, avatarBlurhash: $avatarBlurhash, avatarDecorations: $avatarDecorations, isBot: $isBot, isCat: $isCat, instance: $instance, emojis: $emojis, onlineStatus: $onlineStatus, badgeRoles: $badgeRoles, requireSigninToViewContents: $requireSigninToViewContents, makeNotesFollowersOnlyBefore: $makeNotesFollowersOnlyBefore, makeNotesHiddenBefore: $makeNotesHiddenBefore, url: $url, uri: $uri, movedTo: $movedTo, alsoKnownAs: $alsoKnownAs, createdAt: $createdAt, updatedAt: $updatedAt, lastFetchedAt: $lastFetchedAt, bannerUrl: $bannerUrl, bannerBlurhash: $bannerBlurhash, isLocked: $isLocked, isSilenced: $isSilenced, isSuspended: $isSuspended, description: $description, location: $location, birthday: $birthday, lang: $lang, fields: $fields, verifiedLinks: $verifiedLinks, followersCount: $followersCount, followingCount: $followingCount, notesCount: $notesCount, pinnedNoteIds: $pinnedNoteIds, pinnedNotes: $pinnedNotes, pinnedPageId: $pinnedPageId, pinnedPage: $pinnedPage, publicReactions: $publicReactions, ffVisibility: $ffVisibility, followersVisibility: $followersVisibility, followingVisibility: $followingVisibility, twoFactorEnabled: $twoFactorEnabled, usePasswordLessLogin: $usePasswordLessLogin, securityKeys: $securityKeys, roles: $roles, memo: $memo, moderationNote: $moderationNote, isFollowing: $isFollowing, isFollowed: $isFollowed, hasPendingFollowRequestFromYou: $hasPendingFollowRequestFromYou, hasPendingFollowRequestToYou: $hasPendingFollowRequestToYou, isBlocking: $isBlocking, isBlocked: $isBlocked, isMuted: $isMuted, isRenoteMuted: $isRenoteMuted, notify: $notify, withReplies: $withReplies, followedMessage: $followedMessage)';
   }
 
   @override
@@ -2964,6 +3161,14 @@ class _$UserDetailedNotMeWithRelationsImpl
                 other.onlineStatus == onlineStatus) &&
             const DeepCollectionEquality()
                 .equals(other._badgeRoles, _badgeRoles) &&
+            (identical(other.requireSigninToViewContents, requireSigninToViewContents) ||
+                other.requireSigninToViewContents ==
+                    requireSigninToViewContents) &&
+            (identical(other.makeNotesFollowersOnlyBefore, makeNotesFollowersOnlyBefore) ||
+                other.makeNotesFollowersOnlyBefore ==
+                    makeNotesFollowersOnlyBefore) &&
+            (identical(other.makeNotesHiddenBefore, makeNotesHiddenBefore) ||
+                other.makeNotesHiddenBefore == makeNotesHiddenBefore) &&
             (identical(other.url, url) || other.url == url) &&
             (identical(other.uri, uri) || other.uri == uri) &&
             (identical(other.movedTo, movedTo) || other.movedTo == movedTo) &&
@@ -3005,42 +3210,24 @@ class _$UserDetailedNotMeWithRelationsImpl
                 .equals(other._pinnedNoteIds, _pinnedNoteIds) &&
             const DeepCollectionEquality()
                 .equals(other._pinnedNotes, _pinnedNotes) &&
-            (identical(other.pinnedPageId, pinnedPageId) ||
-                other.pinnedPageId == pinnedPageId) &&
-            const DeepCollectionEquality()
-                .equals(other._pinnedPage, _pinnedPage) &&
-            (identical(other.publicReactions, publicReactions) ||
-                other.publicReactions == publicReactions) &&
-            (identical(other.ffVisibility, ffVisibility) ||
-                other.ffVisibility == ffVisibility) &&
-            (identical(other.followersVisibility, followersVisibility) ||
-                other.followersVisibility == followersVisibility) &&
-            (identical(other.followingVisibility, followingVisibility) ||
-                other.followingVisibility == followingVisibility) &&
-            (identical(other.twoFactorEnabled, twoFactorEnabled) ||
-                other.twoFactorEnabled == twoFactorEnabled) &&
-            (identical(other.usePasswordLessLogin, usePasswordLessLogin) ||
-                other.usePasswordLessLogin == usePasswordLessLogin) &&
-            (identical(other.securityKeys, securityKeys) ||
-                other.securityKeys == securityKeys) &&
+            (identical(other.pinnedPageId, pinnedPageId) || other.pinnedPageId == pinnedPageId) &&
+            const DeepCollectionEquality().equals(other._pinnedPage, _pinnedPage) &&
+            (identical(other.publicReactions, publicReactions) || other.publicReactions == publicReactions) &&
+            (identical(other.ffVisibility, ffVisibility) || other.ffVisibility == ffVisibility) &&
+            (identical(other.followersVisibility, followersVisibility) || other.followersVisibility == followersVisibility) &&
+            (identical(other.followingVisibility, followingVisibility) || other.followingVisibility == followingVisibility) &&
+            (identical(other.twoFactorEnabled, twoFactorEnabled) || other.twoFactorEnabled == twoFactorEnabled) &&
+            (identical(other.usePasswordLessLogin, usePasswordLessLogin) || other.usePasswordLessLogin == usePasswordLessLogin) &&
+            (identical(other.securityKeys, securityKeys) || other.securityKeys == securityKeys) &&
             const DeepCollectionEquality().equals(other._roles, _roles) &&
             (identical(other.memo, memo) || other.memo == memo) &&
-            (identical(other.moderationNote, moderationNote) ||
-                other.moderationNote == moderationNote) &&
-            (identical(other.isFollowing, isFollowing) ||
-                other.isFollowing == isFollowing) &&
-            (identical(other.isFollowed, isFollowed) ||
-                other.isFollowed == isFollowed) &&
-            (identical(other.hasPendingFollowRequestFromYou, hasPendingFollowRequestFromYou) ||
-                other.hasPendingFollowRequestFromYou ==
-                    hasPendingFollowRequestFromYou) &&
-            (identical(other.hasPendingFollowRequestToYou, hasPendingFollowRequestToYou) ||
-                other.hasPendingFollowRequestToYou ==
-                    hasPendingFollowRequestToYou) &&
-            (identical(other.isBlocking, isBlocking) ||
-                other.isBlocking == isBlocking) &&
-            (identical(other.isBlocked, isBlocked) ||
-                other.isBlocked == isBlocked) &&
+            (identical(other.moderationNote, moderationNote) || other.moderationNote == moderationNote) &&
+            (identical(other.isFollowing, isFollowing) || other.isFollowing == isFollowing) &&
+            (identical(other.isFollowed, isFollowed) || other.isFollowed == isFollowed) &&
+            (identical(other.hasPendingFollowRequestFromYou, hasPendingFollowRequestFromYou) || other.hasPendingFollowRequestFromYou == hasPendingFollowRequestFromYou) &&
+            (identical(other.hasPendingFollowRequestToYou, hasPendingFollowRequestToYou) || other.hasPendingFollowRequestToYou == hasPendingFollowRequestToYou) &&
+            (identical(other.isBlocking, isBlocking) || other.isBlocking == isBlocking) &&
+            (identical(other.isBlocked, isBlocked) || other.isBlocked == isBlocked) &&
             (identical(other.isMuted, isMuted) || other.isMuted == isMuted) &&
             (identical(other.isRenoteMuted, isRenoteMuted) || other.isRenoteMuted == isRenoteMuted) &&
             (identical(other.notify, notify) || other.notify == notify) &&
@@ -3065,6 +3252,9 @@ class _$UserDetailedNotMeWithRelationsImpl
         const DeepCollectionEquality().hash(_emojis),
         onlineStatus,
         const DeepCollectionEquality().hash(_badgeRoles),
+        requireSigninToViewContents,
+        makeNotesFollowersOnlyBefore,
+        makeNotesHiddenBefore,
         url,
         uri,
         movedTo,
@@ -3145,6 +3335,9 @@ abstract class _UserDetailedNotMeWithRelations
       @EmojisConverter() final Map<String, String> emojis,
       @OnlineStatusJsonConverter() final OnlineStatus? onlineStatus,
       final List<UserBadgeRole> badgeRoles,
+      final bool? requireSigninToViewContents,
+      @HideBeforeConverter() final HideBefore? makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() final HideBefore? makeNotesHiddenBefore,
       @NullableUriConverter() final Uri? url,
       @NullableUriConverter() final Uri? uri,
       @NullableUriConverter() final Uri? movedTo,
@@ -3224,6 +3417,14 @@ abstract class _UserDetailedNotMeWithRelations
   OnlineStatus? get onlineStatus;
   @override
   List<UserBadgeRole> get badgeRoles;
+  @override
+  bool? get requireSigninToViewContents;
+  @override
+  @HideBeforeConverter()
+  HideBefore? get makeNotesFollowersOnlyBefore;
+  @override
+  @HideBeforeConverter()
+  HideBefore? get makeNotesHiddenBefore;
   @override
   @NullableUriConverter()
   Uri? get url;
@@ -3355,6 +3556,12 @@ mixin _$MeDetailed {
   @OnlineStatusJsonConverter()
   OnlineStatus? get onlineStatus => throw _privateConstructorUsedError;
   List<UserBadgeRole> get badgeRoles => throw _privateConstructorUsedError;
+  bool? get requireSigninToViewContents => throw _privateConstructorUsedError;
+  @HideBeforeConverter()
+  HideBefore? get makeNotesFollowersOnlyBefore =>
+      throw _privateConstructorUsedError;
+  @HideBeforeConverter()
+  HideBefore? get makeNotesHiddenBefore => throw _privateConstructorUsedError;
   @NullableUriConverter()
   Uri? get url => throw _privateConstructorUsedError;
   @NullableUriConverter()
@@ -3469,6 +3676,9 @@ abstract class $MeDetailedCopyWith<$Res> {
       @EmojisConverter() Map<String, String> emojis,
       @OnlineStatusJsonConverter() OnlineStatus? onlineStatus,
       List<UserBadgeRole> badgeRoles,
+      bool? requireSigninToViewContents,
+      @HideBeforeConverter() HideBefore? makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() HideBefore? makeNotesHiddenBefore,
       @NullableUriConverter() Uri? url,
       @NullableUriConverter() Uri? uri,
       @NullableUriConverter() Uri? movedTo,
@@ -3572,6 +3782,9 @@ class _$MeDetailedCopyWithImpl<$Res, $Val extends MeDetailed>
     Object? emojis = null,
     Object? onlineStatus = freezed,
     Object? badgeRoles = null,
+    Object? requireSigninToViewContents = freezed,
+    Object? makeNotesFollowersOnlyBefore = freezed,
+    Object? makeNotesHiddenBefore = freezed,
     Object? url = freezed,
     Object? uri = freezed,
     Object? movedTo = freezed,
@@ -3696,6 +3909,18 @@ class _$MeDetailedCopyWithImpl<$Res, $Val extends MeDetailed>
           ? _value.badgeRoles
           : badgeRoles // ignore: cast_nullable_to_non_nullable
               as List<UserBadgeRole>,
+      requireSigninToViewContents: freezed == requireSigninToViewContents
+          ? _value.requireSigninToViewContents
+          : requireSigninToViewContents // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      makeNotesFollowersOnlyBefore: freezed == makeNotesFollowersOnlyBefore
+          ? _value.makeNotesFollowersOnlyBefore
+          : makeNotesFollowersOnlyBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
+      makeNotesHiddenBefore: freezed == makeNotesHiddenBefore
+          ? _value.makeNotesHiddenBefore
+          : makeNotesHiddenBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
       url: freezed == url
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
@@ -4031,6 +4256,9 @@ abstract class _$$MeDetailedImplCopyWith<$Res>
       @EmojisConverter() Map<String, String> emojis,
       @OnlineStatusJsonConverter() OnlineStatus? onlineStatus,
       List<UserBadgeRole> badgeRoles,
+      bool? requireSigninToViewContents,
+      @HideBeforeConverter() HideBefore? makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() HideBefore? makeNotesHiddenBefore,
       @NullableUriConverter() Uri? url,
       @NullableUriConverter() Uri? uri,
       @NullableUriConverter() Uri? movedTo,
@@ -4135,6 +4363,9 @@ class __$$MeDetailedImplCopyWithImpl<$Res>
     Object? emojis = null,
     Object? onlineStatus = freezed,
     Object? badgeRoles = null,
+    Object? requireSigninToViewContents = freezed,
+    Object? makeNotesFollowersOnlyBefore = freezed,
+    Object? makeNotesHiddenBefore = freezed,
     Object? url = freezed,
     Object? uri = freezed,
     Object? movedTo = freezed,
@@ -4259,6 +4490,18 @@ class __$$MeDetailedImplCopyWithImpl<$Res>
           ? _value._badgeRoles
           : badgeRoles // ignore: cast_nullable_to_non_nullable
               as List<UserBadgeRole>,
+      requireSigninToViewContents: freezed == requireSigninToViewContents
+          ? _value.requireSigninToViewContents
+          : requireSigninToViewContents // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      makeNotesFollowersOnlyBefore: freezed == makeNotesFollowersOnlyBefore
+          ? _value.makeNotesFollowersOnlyBefore
+          : makeNotesFollowersOnlyBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
+      makeNotesHiddenBefore: freezed == makeNotesHiddenBefore
+          ? _value.makeNotesHiddenBefore
+          : makeNotesHiddenBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
       url: freezed == url
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
@@ -4560,6 +4803,9 @@ class _$MeDetailedImpl implements _MeDetailed {
       @EmojisConverter() final Map<String, String> emojis = const {},
       @OnlineStatusJsonConverter() this.onlineStatus,
       final List<UserBadgeRole> badgeRoles = const [],
+      this.requireSigninToViewContents,
+      @HideBeforeConverter() this.makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() this.makeNotesHiddenBefore,
       @NullableUriConverter() this.url,
       @NullableUriConverter() this.uri,
       @NullableUriConverter() this.movedTo,
@@ -4703,6 +4949,14 @@ class _$MeDetailedImpl implements _MeDetailed {
     return EqualUnmodifiableListView(_badgeRoles);
   }
 
+  @override
+  final bool? requireSigninToViewContents;
+  @override
+  @HideBeforeConverter()
+  final HideBefore? makeNotesFollowersOnlyBefore;
+  @override
+  @HideBeforeConverter()
+  final HideBefore? makeNotesHiddenBefore;
   @override
   @NullableUriConverter()
   final Uri? url;
@@ -4963,7 +5217,7 @@ class _$MeDetailedImpl implements _MeDetailed {
 
   @override
   String toString() {
-    return 'MeDetailed(id: $id, name: $name, username: $username, host: $host, avatarUrl: $avatarUrl, avatarBlurhash: $avatarBlurhash, avatarDecorations: $avatarDecorations, isBot: $isBot, isCat: $isCat, instance: $instance, emojis: $emojis, onlineStatus: $onlineStatus, badgeRoles: $badgeRoles, url: $url, uri: $uri, movedTo: $movedTo, alsoKnownAs: $alsoKnownAs, createdAt: $createdAt, updatedAt: $updatedAt, lastFetchedAt: $lastFetchedAt, bannerUrl: $bannerUrl, bannerBlurhash: $bannerBlurhash, isLocked: $isLocked, isSilenced: $isSilenced, isSuspended: $isSuspended, description: $description, location: $location, birthday: $birthday, lang: $lang, fields: $fields, verifiedLinks: $verifiedLinks, followersCount: $followersCount, followingCount: $followingCount, notesCount: $notesCount, pinnedNoteIds: $pinnedNoteIds, pinnedNotes: $pinnedNotes, pinnedPageId: $pinnedPageId, pinnedPage: $pinnedPage, publicReactions: $publicReactions, ffVisibility: $ffVisibility, followersVisibility: $followersVisibility, followingVisibility: $followingVisibility, twoFactorEnabled: $twoFactorEnabled, usePasswordLessLogin: $usePasswordLessLogin, securityKeys: $securityKeys, roles: $roles, memo: $memo, moderationNote: $moderationNote, avatarId: $avatarId, bannerId: $bannerId, followedMessage: $followedMessage, isModerator: $isModerator, isAdmin: $isAdmin, injectFeaturedNote: $injectFeaturedNote, receiveAnnouncementEmail: $receiveAnnouncementEmail, alwaysMarkNsfw: $alwaysMarkNsfw, autoSensitive: $autoSensitive, carefulBot: $carefulBot, autoAcceptFollowed: $autoAcceptFollowed, preventAiLearning: $preventAiLearning, noCrawle: $noCrawle, isExplorable: $isExplorable, isDeleted: $isDeleted, twoFactorBackupCodesStock: $twoFactorBackupCodesStock, hideOnlineStatus: $hideOnlineStatus, hasUnreadSpecifiedNotes: $hasUnreadSpecifiedNotes, hasUnreadMentions: $hasUnreadMentions, hasUnreadAnnouncement: $hasUnreadAnnouncement, hasUnreadAntenna: $hasUnreadAntenna, hasUnreadChannel: $hasUnreadChannel, hasUnreadNotification: $hasUnreadNotification, hasPendingReceivedFollowRequest: $hasPendingReceivedFollowRequest, unreadNotificationsCount: $unreadNotificationsCount, unreadAnnouncements: $unreadAnnouncements, mutedWords: $mutedWords, hardMutedWords: $hardMutedWords, mutedInstances: $mutedInstances, mutingNotificationTypes: $mutingNotificationTypes, notificationRecieveConfig: $notificationRecieveConfig, emailNotificationTypes: $emailNotificationTypes, achievements: $achievements, loggedInDays: $loggedInDays, policies: $policies)';
+    return 'MeDetailed(id: $id, name: $name, username: $username, host: $host, avatarUrl: $avatarUrl, avatarBlurhash: $avatarBlurhash, avatarDecorations: $avatarDecorations, isBot: $isBot, isCat: $isCat, instance: $instance, emojis: $emojis, onlineStatus: $onlineStatus, badgeRoles: $badgeRoles, requireSigninToViewContents: $requireSigninToViewContents, makeNotesFollowersOnlyBefore: $makeNotesFollowersOnlyBefore, makeNotesHiddenBefore: $makeNotesHiddenBefore, url: $url, uri: $uri, movedTo: $movedTo, alsoKnownAs: $alsoKnownAs, createdAt: $createdAt, updatedAt: $updatedAt, lastFetchedAt: $lastFetchedAt, bannerUrl: $bannerUrl, bannerBlurhash: $bannerBlurhash, isLocked: $isLocked, isSilenced: $isSilenced, isSuspended: $isSuspended, description: $description, location: $location, birthday: $birthday, lang: $lang, fields: $fields, verifiedLinks: $verifiedLinks, followersCount: $followersCount, followingCount: $followingCount, notesCount: $notesCount, pinnedNoteIds: $pinnedNoteIds, pinnedNotes: $pinnedNotes, pinnedPageId: $pinnedPageId, pinnedPage: $pinnedPage, publicReactions: $publicReactions, ffVisibility: $ffVisibility, followersVisibility: $followersVisibility, followingVisibility: $followingVisibility, twoFactorEnabled: $twoFactorEnabled, usePasswordLessLogin: $usePasswordLessLogin, securityKeys: $securityKeys, roles: $roles, memo: $memo, moderationNote: $moderationNote, avatarId: $avatarId, bannerId: $bannerId, followedMessage: $followedMessage, isModerator: $isModerator, isAdmin: $isAdmin, injectFeaturedNote: $injectFeaturedNote, receiveAnnouncementEmail: $receiveAnnouncementEmail, alwaysMarkNsfw: $alwaysMarkNsfw, autoSensitive: $autoSensitive, carefulBot: $carefulBot, autoAcceptFollowed: $autoAcceptFollowed, preventAiLearning: $preventAiLearning, noCrawle: $noCrawle, isExplorable: $isExplorable, isDeleted: $isDeleted, twoFactorBackupCodesStock: $twoFactorBackupCodesStock, hideOnlineStatus: $hideOnlineStatus, hasUnreadSpecifiedNotes: $hasUnreadSpecifiedNotes, hasUnreadMentions: $hasUnreadMentions, hasUnreadAnnouncement: $hasUnreadAnnouncement, hasUnreadAntenna: $hasUnreadAntenna, hasUnreadChannel: $hasUnreadChannel, hasUnreadNotification: $hasUnreadNotification, hasPendingReceivedFollowRequest: $hasPendingReceivedFollowRequest, unreadNotificationsCount: $unreadNotificationsCount, unreadAnnouncements: $unreadAnnouncements, mutedWords: $mutedWords, hardMutedWords: $hardMutedWords, mutedInstances: $mutedInstances, mutingNotificationTypes: $mutingNotificationTypes, notificationRecieveConfig: $notificationRecieveConfig, emailNotificationTypes: $emailNotificationTypes, achievements: $achievements, loggedInDays: $loggedInDays, policies: $policies)';
   }
 
   @override
@@ -4991,6 +5245,14 @@ class _$MeDetailedImpl implements _MeDetailed {
                 other.onlineStatus == onlineStatus) &&
             const DeepCollectionEquality()
                 .equals(other._badgeRoles, _badgeRoles) &&
+            (identical(other.requireSigninToViewContents, requireSigninToViewContents) ||
+                other.requireSigninToViewContents ==
+                    requireSigninToViewContents) &&
+            (identical(other.makeNotesFollowersOnlyBefore, makeNotesFollowersOnlyBefore) ||
+                other.makeNotesFollowersOnlyBefore ==
+                    makeNotesFollowersOnlyBefore) &&
+            (identical(other.makeNotesHiddenBefore, makeNotesHiddenBefore) ||
+                other.makeNotesHiddenBefore == makeNotesHiddenBefore) &&
             (identical(other.url, url) || other.url == url) &&
             (identical(other.uri, uri) || other.uri == uri) &&
             (identical(other.movedTo, movedTo) || other.movedTo == movedTo) &&
@@ -5032,45 +5294,27 @@ class _$MeDetailedImpl implements _MeDetailed {
                 .equals(other._pinnedNoteIds, _pinnedNoteIds) &&
             const DeepCollectionEquality()
                 .equals(other._pinnedNotes, _pinnedNotes) &&
-            (identical(other.pinnedPageId, pinnedPageId) ||
-                other.pinnedPageId == pinnedPageId) &&
-            const DeepCollectionEquality()
-                .equals(other._pinnedPage, _pinnedPage) &&
-            (identical(other.publicReactions, publicReactions) ||
-                other.publicReactions == publicReactions) &&
-            (identical(other.ffVisibility, ffVisibility) ||
-                other.ffVisibility == ffVisibility) &&
-            (identical(other.followersVisibility, followersVisibility) ||
-                other.followersVisibility == followersVisibility) &&
-            (identical(other.followingVisibility, followingVisibility) ||
-                other.followingVisibility == followingVisibility) &&
-            (identical(other.twoFactorEnabled, twoFactorEnabled) ||
-                other.twoFactorEnabled == twoFactorEnabled) &&
-            (identical(other.usePasswordLessLogin, usePasswordLessLogin) ||
-                other.usePasswordLessLogin == usePasswordLessLogin) &&
-            (identical(other.securityKeys, securityKeys) ||
-                other.securityKeys == securityKeys) &&
+            (identical(other.pinnedPageId, pinnedPageId) || other.pinnedPageId == pinnedPageId) &&
+            const DeepCollectionEquality().equals(other._pinnedPage, _pinnedPage) &&
+            (identical(other.publicReactions, publicReactions) || other.publicReactions == publicReactions) &&
+            (identical(other.ffVisibility, ffVisibility) || other.ffVisibility == ffVisibility) &&
+            (identical(other.followersVisibility, followersVisibility) || other.followersVisibility == followersVisibility) &&
+            (identical(other.followingVisibility, followingVisibility) || other.followingVisibility == followingVisibility) &&
+            (identical(other.twoFactorEnabled, twoFactorEnabled) || other.twoFactorEnabled == twoFactorEnabled) &&
+            (identical(other.usePasswordLessLogin, usePasswordLessLogin) || other.usePasswordLessLogin == usePasswordLessLogin) &&
+            (identical(other.securityKeys, securityKeys) || other.securityKeys == securityKeys) &&
             const DeepCollectionEquality().equals(other._roles, _roles) &&
             (identical(other.memo, memo) || other.memo == memo) &&
-            (identical(other.moderationNote, moderationNote) ||
-                other.moderationNote == moderationNote) &&
-            (identical(other.avatarId, avatarId) ||
-                other.avatarId == avatarId) &&
-            (identical(other.bannerId, bannerId) ||
-                other.bannerId == bannerId) &&
-            (identical(other.followedMessage, followedMessage) ||
-                other.followedMessage == followedMessage) &&
-            (identical(other.isModerator, isModerator) ||
-                other.isModerator == isModerator) &&
+            (identical(other.moderationNote, moderationNote) || other.moderationNote == moderationNote) &&
+            (identical(other.avatarId, avatarId) || other.avatarId == avatarId) &&
+            (identical(other.bannerId, bannerId) || other.bannerId == bannerId) &&
+            (identical(other.followedMessage, followedMessage) || other.followedMessage == followedMessage) &&
+            (identical(other.isModerator, isModerator) || other.isModerator == isModerator) &&
             (identical(other.isAdmin, isAdmin) || other.isAdmin == isAdmin) &&
-            (identical(other.injectFeaturedNote, injectFeaturedNote) ||
-                other.injectFeaturedNote == injectFeaturedNote) &&
-            (identical(other.receiveAnnouncementEmail, receiveAnnouncementEmail) ||
-                other.receiveAnnouncementEmail == receiveAnnouncementEmail) &&
-            (identical(other.alwaysMarkNsfw, alwaysMarkNsfw) ||
-                other.alwaysMarkNsfw == alwaysMarkNsfw) &&
-            (identical(other.autoSensitive, autoSensitive) ||
-                other.autoSensitive == autoSensitive) &&
+            (identical(other.injectFeaturedNote, injectFeaturedNote) || other.injectFeaturedNote == injectFeaturedNote) &&
+            (identical(other.receiveAnnouncementEmail, receiveAnnouncementEmail) || other.receiveAnnouncementEmail == receiveAnnouncementEmail) &&
+            (identical(other.alwaysMarkNsfw, alwaysMarkNsfw) || other.alwaysMarkNsfw == alwaysMarkNsfw) &&
+            (identical(other.autoSensitive, autoSensitive) || other.autoSensitive == autoSensitive) &&
             (identical(other.carefulBot, carefulBot) || other.carefulBot == carefulBot) &&
             (identical(other.autoAcceptFollowed, autoAcceptFollowed) || other.autoAcceptFollowed == autoAcceptFollowed) &&
             (identical(other.preventAiLearning, preventAiLearning) || other.preventAiLearning == preventAiLearning) &&
@@ -5116,6 +5360,9 @@ class _$MeDetailedImpl implements _MeDetailed {
         const DeepCollectionEquality().hash(_emojis),
         onlineStatus,
         const DeepCollectionEquality().hash(_badgeRoles),
+        requireSigninToViewContents,
+        makeNotesFollowersOnlyBefore,
+        makeNotesHiddenBefore,
         url,
         uri,
         movedTo,
@@ -5217,6 +5464,9 @@ abstract class _MeDetailed implements MeDetailed {
       @EmojisConverter() final Map<String, String> emojis,
       @OnlineStatusJsonConverter() final OnlineStatus? onlineStatus,
       final List<UserBadgeRole> badgeRoles,
+      final bool? requireSigninToViewContents,
+      @HideBeforeConverter() final HideBefore? makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() final HideBefore? makeNotesHiddenBefore,
       @NullableUriConverter() final Uri? url,
       @NullableUriConverter() final Uri? uri,
       @NullableUriConverter() final Uri? movedTo,
@@ -5321,6 +5571,14 @@ abstract class _MeDetailed implements MeDetailed {
   OnlineStatus? get onlineStatus;
   @override
   List<UserBadgeRole> get badgeRoles;
+  @override
+  bool? get requireSigninToViewContents;
+  @override
+  @HideBeforeConverter()
+  HideBefore? get makeNotesFollowersOnlyBefore;
+  @override
+  @HideBeforeConverter()
+  HideBefore? get makeNotesHiddenBefore;
   @override
   @NullableUriConverter()
   Uri? get url;

--- a/lib/src/data/base/user.g.dart
+++ b/lib/src/data/base/user.g.dart
@@ -33,6 +33,12 @@ _$UserLiteImpl _$$UserLiteImplFromJson(Map<String, dynamic> json) =>
               ?.map((e) => UserBadgeRole.fromJson(e as Map<String, dynamic>))
               .toList() ??
           const [],
+      requireSigninToViewContents: json['requireSigninToViewContents'] as bool?,
+      makeNotesFollowersOnlyBefore: _$JsonConverterFromJson<int, HideBefore>(
+          json['makeNotesFollowersOnlyBefore'],
+          const HideBeforeConverter().fromJson),
+      makeNotesHiddenBefore: _$JsonConverterFromJson<int, HideBefore>(
+          json['makeNotesHiddenBefore'], const HideBeforeConverter().fromJson),
     );
 
 Map<String, dynamic> _$$UserLiteImplToJson(_$UserLiteImpl instance) =>
@@ -52,7 +58,25 @@ Map<String, dynamic> _$$UserLiteImplToJson(_$UserLiteImpl instance) =>
       'onlineStatus':
           const OnlineStatusJsonConverter().toJson(instance.onlineStatus),
       'badgeRoles': instance.badgeRoles.map((e) => e.toJson()).toList(),
+      'requireSigninToViewContents': instance.requireSigninToViewContents,
+      'makeNotesFollowersOnlyBefore': _$JsonConverterToJson<int, HideBefore>(
+          instance.makeNotesFollowersOnlyBefore,
+          const HideBeforeConverter().toJson),
+      'makeNotesHiddenBefore': _$JsonConverterToJson<int, HideBefore>(
+          instance.makeNotesHiddenBefore, const HideBeforeConverter().toJson),
     };
+
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) =>
+    json == null ? null : fromJson(json as Json);
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) =>
+    value == null ? null : toJson(value);
 
 _$UserDetailedNotMeImpl _$$UserDetailedNotMeImplFromJson(
         Map<String, dynamic> json) =>
@@ -82,6 +106,12 @@ _$UserDetailedNotMeImpl _$$UserDetailedNotMeImplFromJson(
               ?.map((e) => UserBadgeRole.fromJson(e as Map<String, dynamic>))
               .toList() ??
           const [],
+      requireSigninToViewContents: json['requireSigninToViewContents'] as bool?,
+      makeNotesFollowersOnlyBefore: _$JsonConverterFromJson<int, HideBefore>(
+          json['makeNotesFollowersOnlyBefore'],
+          const HideBeforeConverter().fromJson),
+      makeNotesHiddenBefore: _$JsonConverterFromJson<int, HideBefore>(
+          json['makeNotesHiddenBefore'], const HideBeforeConverter().fromJson),
       url: _$JsonConverterFromJson<String, Uri?>(
           json['url'], const NullableUriConverter().fromJson),
       uri: _$JsonConverterFromJson<String, Uri?>(
@@ -161,6 +191,12 @@ Map<String, dynamic> _$$UserDetailedNotMeImplToJson(
       'onlineStatus':
           const OnlineStatusJsonConverter().toJson(instance.onlineStatus),
       'badgeRoles': instance.badgeRoles.map((e) => e.toJson()).toList(),
+      'requireSigninToViewContents': instance.requireSigninToViewContents,
+      'makeNotesFollowersOnlyBefore': _$JsonConverterToJson<int, HideBefore>(
+          instance.makeNotesFollowersOnlyBefore,
+          const HideBeforeConverter().toJson),
+      'makeNotesHiddenBefore': _$JsonConverterToJson<int, HideBefore>(
+          instance.makeNotesHiddenBefore, const HideBeforeConverter().toJson),
       'url': const NullableUriConverter().toJson(instance.url),
       'uri': const NullableUriConverter().toJson(instance.uri),
       'movedTo': const NullableUriConverter().toJson(instance.movedTo),
@@ -201,12 +237,6 @@ Map<String, dynamic> _$$UserDetailedNotMeImplToJson(
       'moderationNote': instance.moderationNote,
     };
 
-Value? _$JsonConverterFromJson<Json, Value>(
-  Object? json,
-  Value? Function(Json json) fromJson,
-) =>
-    json == null ? null : fromJson(json as Json);
-
 const _$FFVisibilityEnumMap = {
   FFVisibility.public: 'public',
   FFVisibility.followers: 'followers',
@@ -243,6 +273,15 @@ _$UserDetailedNotMeWithRelationsImpl
                       (e) => UserBadgeRole.fromJson(e as Map<String, dynamic>))
                   .toList() ??
               const [],
+          requireSigninToViewContents:
+              json['requireSigninToViewContents'] as bool?,
+          makeNotesFollowersOnlyBefore:
+              _$JsonConverterFromJson<int, HideBefore>(
+                  json['makeNotesFollowersOnlyBefore'],
+                  const HideBeforeConverter().fromJson),
+          makeNotesHiddenBefore: _$JsonConverterFromJson<int, HideBefore>(
+              json['makeNotesHiddenBefore'],
+              const HideBeforeConverter().fromJson),
           url: _$JsonConverterFromJson<String, Uri?>(
               json['url'], const NullableUriConverter().fromJson),
           uri: _$JsonConverterFromJson<String, Uri?>(
@@ -336,6 +375,12 @@ Map<String, dynamic> _$$UserDetailedNotMeWithRelationsImplToJson(
       'onlineStatus':
           const OnlineStatusJsonConverter().toJson(instance.onlineStatus),
       'badgeRoles': instance.badgeRoles.map((e) => e.toJson()).toList(),
+      'requireSigninToViewContents': instance.requireSigninToViewContents,
+      'makeNotesFollowersOnlyBefore': _$JsonConverterToJson<int, HideBefore>(
+          instance.makeNotesFollowersOnlyBefore,
+          const HideBeforeConverter().toJson),
+      'makeNotesHiddenBefore': _$JsonConverterToJson<int, HideBefore>(
+          instance.makeNotesHiddenBefore, const HideBeforeConverter().toJson),
       'url': const NullableUriConverter().toJson(instance.url),
       'uri': const NullableUriConverter().toJson(instance.uri),
       'movedTo': const NullableUriConverter().toJson(instance.movedTo),
@@ -419,6 +464,12 @@ _$MeDetailedImpl _$$MeDetailedImplFromJson(Map<String, dynamic> json) =>
               ?.map((e) => UserBadgeRole.fromJson(e as Map<String, dynamic>))
               .toList() ??
           const [],
+      requireSigninToViewContents: json['requireSigninToViewContents'] as bool?,
+      makeNotesFollowersOnlyBefore: _$JsonConverterFromJson<int, HideBefore>(
+          json['makeNotesFollowersOnlyBefore'],
+          const HideBeforeConverter().fromJson),
+      makeNotesHiddenBefore: _$JsonConverterFromJson<int, HideBefore>(
+          json['makeNotesHiddenBefore'], const HideBeforeConverter().fromJson),
       url: _$JsonConverterFromJson<String, Uri?>(
           json['url'], const NullableUriConverter().fromJson),
       uri: _$JsonConverterFromJson<String, Uri?>(
@@ -556,6 +607,12 @@ Map<String, dynamic> _$$MeDetailedImplToJson(_$MeDetailedImpl instance) =>
       'onlineStatus':
           const OnlineStatusJsonConverter().toJson(instance.onlineStatus),
       'badgeRoles': instance.badgeRoles.map((e) => e.toJson()).toList(),
+      'requireSigninToViewContents': instance.requireSigninToViewContents,
+      'makeNotesFollowersOnlyBefore': _$JsonConverterToJson<int, HideBefore>(
+          instance.makeNotesFollowersOnlyBefore,
+          const HideBeforeConverter().toJson),
+      'makeNotesHiddenBefore': _$JsonConverterToJson<int, HideBefore>(
+          instance.makeNotesHiddenBefore, const HideBeforeConverter().toJson),
       'url': const NullableUriConverter().toJson(instance.url),
       'uri': const NullableUriConverter().toJson(instance.uri),
       'movedTo': const NullableUriConverter().toJson(instance.movedTo),

--- a/lib/src/data/i/i_update_request.dart
+++ b/lib/src/data/i/i_update_request.dart
@@ -1,6 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 import 'package:misskey_dart/src/converters/date_time_converter.dart';
+import 'package:misskey_dart/src/converters/hide_before_converter.dart';
 import 'package:misskey_dart/src/converters/mute_words_converter.dart';
 
 part 'i_update_request.freezed.dart';
@@ -27,6 +28,9 @@ class IUpdateRequest with _$IUpdateRequest {
     bool? autoAcceptFollowed,
     bool? noCrawle,
     bool? preventAiLearning,
+    bool? requireSigninToViewContents,
+    @HideBeforeConverter() HideBefore? makeNotesFollowersOnlyBefore,
+    @HideBeforeConverter() HideBefore? makeNotesHiddenBefore,
     bool? isBot,
     bool? isCat,
     bool? injectFeaturedNote,

--- a/lib/src/data/i/i_update_request.freezed.dart
+++ b/lib/src/data/i/i_update_request.freezed.dart
@@ -40,6 +40,12 @@ mixin _$IUpdateRequest {
   bool? get autoAcceptFollowed => throw _privateConstructorUsedError;
   bool? get noCrawle => throw _privateConstructorUsedError;
   bool? get preventAiLearning => throw _privateConstructorUsedError;
+  bool? get requireSigninToViewContents => throw _privateConstructorUsedError;
+  @HideBeforeConverter()
+  HideBefore? get makeNotesFollowersOnlyBefore =>
+      throw _privateConstructorUsedError;
+  @HideBeforeConverter()
+  HideBefore? get makeNotesHiddenBefore => throw _privateConstructorUsedError;
   bool? get isBot => throw _privateConstructorUsedError;
   bool? get isCat => throw _privateConstructorUsedError;
   bool? get injectFeaturedNote => throw _privateConstructorUsedError;
@@ -95,6 +101,9 @@ abstract class $IUpdateRequestCopyWith<$Res> {
       bool? autoAcceptFollowed,
       bool? noCrawle,
       bool? preventAiLearning,
+      bool? requireSigninToViewContents,
+      @HideBeforeConverter() HideBefore? makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() HideBefore? makeNotesHiddenBefore,
       bool? isBot,
       bool? isCat,
       bool? injectFeaturedNote,
@@ -147,6 +156,9 @@ class _$IUpdateRequestCopyWithImpl<$Res, $Val extends IUpdateRequest>
     Object? autoAcceptFollowed = freezed,
     Object? noCrawle = freezed,
     Object? preventAiLearning = freezed,
+    Object? requireSigninToViewContents = freezed,
+    Object? makeNotesFollowersOnlyBefore = freezed,
+    Object? makeNotesHiddenBefore = freezed,
     Object? isBot = freezed,
     Object? isCat = freezed,
     Object? injectFeaturedNote = freezed,
@@ -238,6 +250,18 @@ class _$IUpdateRequestCopyWithImpl<$Res, $Val extends IUpdateRequest>
           ? _value.preventAiLearning
           : preventAiLearning // ignore: cast_nullable_to_non_nullable
               as bool?,
+      requireSigninToViewContents: freezed == requireSigninToViewContents
+          ? _value.requireSigninToViewContents
+          : requireSigninToViewContents // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      makeNotesFollowersOnlyBefore: freezed == makeNotesFollowersOnlyBefore
+          ? _value.makeNotesFollowersOnlyBefore
+          : makeNotesFollowersOnlyBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
+      makeNotesHiddenBefore: freezed == makeNotesHiddenBefore
+          ? _value.makeNotesHiddenBefore
+          : makeNotesHiddenBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
       isBot: freezed == isBot
           ? _value.isBot
           : isBot // ignore: cast_nullable_to_non_nullable
@@ -350,6 +374,9 @@ abstract class _$$IUpdateRequestImplCopyWith<$Res>
       bool? autoAcceptFollowed,
       bool? noCrawle,
       bool? preventAiLearning,
+      bool? requireSigninToViewContents,
+      @HideBeforeConverter() HideBefore? makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() HideBefore? makeNotesHiddenBefore,
       bool? isBot,
       bool? isCat,
       bool? injectFeaturedNote,
@@ -401,6 +428,9 @@ class __$$IUpdateRequestImplCopyWithImpl<$Res>
     Object? autoAcceptFollowed = freezed,
     Object? noCrawle = freezed,
     Object? preventAiLearning = freezed,
+    Object? requireSigninToViewContents = freezed,
+    Object? makeNotesFollowersOnlyBefore = freezed,
+    Object? makeNotesHiddenBefore = freezed,
     Object? isBot = freezed,
     Object? isCat = freezed,
     Object? injectFeaturedNote = freezed,
@@ -489,6 +519,18 @@ class __$$IUpdateRequestImplCopyWithImpl<$Res>
           ? _value.preventAiLearning
           : preventAiLearning // ignore: cast_nullable_to_non_nullable
               as bool?,
+      requireSigninToViewContents: freezed == requireSigninToViewContents
+          ? _value.requireSigninToViewContents
+          : requireSigninToViewContents // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      makeNotesFollowersOnlyBefore: freezed == makeNotesFollowersOnlyBefore
+          ? _value.makeNotesFollowersOnlyBefore
+          : makeNotesFollowersOnlyBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
+      makeNotesHiddenBefore: freezed == makeNotesHiddenBefore
+          ? _value.makeNotesHiddenBefore
+          : makeNotesHiddenBefore // ignore: cast_nullable_to_non_nullable
+              as HideBefore?,
       isBot: freezed == isBot
           ? _value.isBot
           : isBot // ignore: cast_nullable_to_non_nullable
@@ -583,6 +625,9 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
       this.autoAcceptFollowed,
       this.noCrawle,
       this.preventAiLearning,
+      this.requireSigninToViewContents,
+      @HideBeforeConverter() this.makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() this.makeNotesHiddenBefore,
       this.isBot,
       this.isCat,
       this.injectFeaturedNote,
@@ -666,6 +711,14 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
   final bool? noCrawle;
   @override
   final bool? preventAiLearning;
+  @override
+  final bool? requireSigninToViewContents;
+  @override
+  @HideBeforeConverter()
+  final HideBefore? makeNotesFollowersOnlyBefore;
+  @override
+  @HideBeforeConverter()
+  final HideBefore? makeNotesHiddenBefore;
   @override
   final bool? isBot;
   @override
@@ -755,7 +808,7 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
 
   @override
   String toString() {
-    return 'IUpdateRequest(name: $name, description: $description, followedMessage: $followedMessage, location: $location, birthday: $birthday, lang: $lang, avatarId: $avatarId, avatarDecorations: $avatarDecorations, bannerId: $bannerId, fields: $fields, isLocked: $isLocked, isExplorable: $isExplorable, hideOnlineStatus: $hideOnlineStatus, publicReactions: $publicReactions, carefulBot: $carefulBot, autoAcceptFollowed: $autoAcceptFollowed, noCrawle: $noCrawle, preventAiLearning: $preventAiLearning, isBot: $isBot, isCat: $isCat, injectFeaturedNote: $injectFeaturedNote, receiveAnnouncementEmail: $receiveAnnouncementEmail, alwaysMarkNsfw: $alwaysMarkNsfw, autoSensitive: $autoSensitive, ffVisibility: $ffVisibility, followingVisibility: $followingVisibility, followersVisibility: $followersVisibility, pinnedPageId: $pinnedPageId, mutingNotificationTypes: $mutingNotificationTypes, mutedWords: $mutedWords, hardMutedWords: $hardMutedWords, mutedInstances: $mutedInstances, notificationRecieveConfig: $notificationRecieveConfig, emailNotificationTypes: $emailNotificationTypes, alsoKnownAs: $alsoKnownAs)';
+    return 'IUpdateRequest(name: $name, description: $description, followedMessage: $followedMessage, location: $location, birthday: $birthday, lang: $lang, avatarId: $avatarId, avatarDecorations: $avatarDecorations, bannerId: $bannerId, fields: $fields, isLocked: $isLocked, isExplorable: $isExplorable, hideOnlineStatus: $hideOnlineStatus, publicReactions: $publicReactions, carefulBot: $carefulBot, autoAcceptFollowed: $autoAcceptFollowed, noCrawle: $noCrawle, preventAiLearning: $preventAiLearning, requireSigninToViewContents: $requireSigninToViewContents, makeNotesFollowersOnlyBefore: $makeNotesFollowersOnlyBefore, makeNotesHiddenBefore: $makeNotesHiddenBefore, isBot: $isBot, isCat: $isCat, injectFeaturedNote: $injectFeaturedNote, receiveAnnouncementEmail: $receiveAnnouncementEmail, alwaysMarkNsfw: $alwaysMarkNsfw, autoSensitive: $autoSensitive, ffVisibility: $ffVisibility, followingVisibility: $followingVisibility, followersVisibility: $followersVisibility, pinnedPageId: $pinnedPageId, mutingNotificationTypes: $mutingNotificationTypes, mutedWords: $mutedWords, hardMutedWords: $hardMutedWords, mutedInstances: $mutedInstances, notificationRecieveConfig: $notificationRecieveConfig, emailNotificationTypes: $emailNotificationTypes, alsoKnownAs: $alsoKnownAs)';
   }
 
   @override
@@ -795,12 +848,19 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
                 other.noCrawle == noCrawle) &&
             (identical(other.preventAiLearning, preventAiLearning) ||
                 other.preventAiLearning == preventAiLearning) &&
+            (identical(other.requireSigninToViewContents, requireSigninToViewContents) ||
+                other.requireSigninToViewContents ==
+                    requireSigninToViewContents) &&
+            (identical(other.makeNotesFollowersOnlyBefore, makeNotesFollowersOnlyBefore) ||
+                other.makeNotesFollowersOnlyBefore ==
+                    makeNotesFollowersOnlyBefore) &&
+            (identical(other.makeNotesHiddenBefore, makeNotesHiddenBefore) ||
+                other.makeNotesHiddenBefore == makeNotesHiddenBefore) &&
             (identical(other.isBot, isBot) || other.isBot == isBot) &&
             (identical(other.isCat, isCat) || other.isCat == isCat) &&
             (identical(other.injectFeaturedNote, injectFeaturedNote) ||
                 other.injectFeaturedNote == injectFeaturedNote) &&
-            (identical(
-                    other.receiveAnnouncementEmail, receiveAnnouncementEmail) ||
+            (identical(other.receiveAnnouncementEmail, receiveAnnouncementEmail) ||
                 other.receiveAnnouncementEmail == receiveAnnouncementEmail) &&
             (identical(other.alwaysMarkNsfw, alwaysMarkNsfw) ||
                 other.alwaysMarkNsfw == alwaysMarkNsfw) &&
@@ -822,13 +882,10 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
                 .equals(other._hardMutedWords, _hardMutedWords) &&
             const DeepCollectionEquality()
                 .equals(other._mutedInstances, _mutedInstances) &&
-            (identical(other.notificationRecieveConfig,
-                    notificationRecieveConfig) ||
+            (identical(other.notificationRecieveConfig, notificationRecieveConfig) ||
                 other.notificationRecieveConfig == notificationRecieveConfig) &&
-            const DeepCollectionEquality().equals(
-                other._emailNotificationTypes, _emailNotificationTypes) &&
-            const DeepCollectionEquality()
-                .equals(other._alsoKnownAs, _alsoKnownAs));
+            const DeepCollectionEquality().equals(other._emailNotificationTypes, _emailNotificationTypes) &&
+            const DeepCollectionEquality().equals(other._alsoKnownAs, _alsoKnownAs));
   }
 
   @JsonKey(ignore: true)
@@ -853,6 +910,9 @@ class _$IUpdateRequestImpl implements _IUpdateRequest {
         autoAcceptFollowed,
         noCrawle,
         preventAiLearning,
+        requireSigninToViewContents,
+        makeNotesFollowersOnlyBefore,
+        makeNotesHiddenBefore,
         isBot,
         isCat,
         injectFeaturedNote,
@@ -907,6 +967,9 @@ abstract class _IUpdateRequest implements IUpdateRequest {
       final bool? autoAcceptFollowed,
       final bool? noCrawle,
       final bool? preventAiLearning,
+      final bool? requireSigninToViewContents,
+      @HideBeforeConverter() final HideBefore? makeNotesFollowersOnlyBefore,
+      @HideBeforeConverter() final HideBefore? makeNotesHiddenBefore,
       final bool? isBot,
       final bool? isCat,
       final bool? injectFeaturedNote,
@@ -965,6 +1028,14 @@ abstract class _IUpdateRequest implements IUpdateRequest {
   bool? get noCrawle;
   @override
   bool? get preventAiLearning;
+  @override
+  bool? get requireSigninToViewContents;
+  @override
+  @HideBeforeConverter()
+  HideBefore? get makeNotesFollowersOnlyBefore;
+  @override
+  @HideBeforeConverter()
+  HideBefore? get makeNotesHiddenBefore;
   @override
   bool? get isBot;
   @override

--- a/lib/src/data/i/i_update_request.g.dart
+++ b/lib/src/data/i/i_update_request.g.dart
@@ -31,6 +31,12 @@ _$IUpdateRequestImpl _$$IUpdateRequestImplFromJson(Map<String, dynamic> json) =>
       autoAcceptFollowed: json['autoAcceptFollowed'] as bool?,
       noCrawle: json['noCrawle'] as bool?,
       preventAiLearning: json['preventAiLearning'] as bool?,
+      requireSigninToViewContents: json['requireSigninToViewContents'] as bool?,
+      makeNotesFollowersOnlyBefore: _$JsonConverterFromJson<int, HideBefore>(
+          json['makeNotesFollowersOnlyBefore'],
+          const HideBeforeConverter().fromJson),
+      makeNotesHiddenBefore: _$JsonConverterFromJson<int, HideBefore>(
+          json['makeNotesHiddenBefore'], const HideBeforeConverter().fromJson),
       isBot: json['isBot'] as bool?,
       isCat: json['isCat'] as bool?,
       injectFeaturedNote: json['injectFeaturedNote'] as bool?,
@@ -91,6 +97,12 @@ Map<String, dynamic> _$$IUpdateRequestImplToJson(
       'autoAcceptFollowed': instance.autoAcceptFollowed,
       'noCrawle': instance.noCrawle,
       'preventAiLearning': instance.preventAiLearning,
+      'requireSigninToViewContents': instance.requireSigninToViewContents,
+      'makeNotesFollowersOnlyBefore': _$JsonConverterToJson<int, HideBefore>(
+          instance.makeNotesFollowersOnlyBefore,
+          const HideBeforeConverter().toJson),
+      'makeNotesHiddenBefore': _$JsonConverterToJson<int, HideBefore>(
+          instance.makeNotesHiddenBefore, const HideBeforeConverter().toJson),
       'isBot': instance.isBot,
       'isCat': instance.isCat,
       'injectFeaturedNote': instance.injectFeaturedNote,
@@ -115,11 +127,23 @@ Map<String, dynamic> _$$IUpdateRequestImplToJson(
       'alsoKnownAs': instance.alsoKnownAs,
     };
 
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) =>
+    json == null ? null : fromJson(json as Json);
+
 const _$FFVisibilityEnumMap = {
   FFVisibility.public: 'public',
   FFVisibility.followers: 'followers',
   FFVisibility.private: 'private',
 };
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) =>
+    value == null ? null : toJson(value);
 
 _$IUpdateAvatarDecorationImpl _$$IUpdateAvatarDecorationImplFromJson(
         Map<String, dynamic> json) =>


### PR DESCRIPTION
Misskey 2024.11.0 で追加されたノートの閲覧にログイン必須にする設定と過去のノートを非公開化/フォロワーのみ表示可能にできる機能に対応しました

ref: `https://github.com/misskey-dev/misskey/pull/14799`
ref: `https://github.com/misskey-dev/misskey/pull/14814`
