### PR TITLE
driveFileCreatedを修正

### DIFF
--- a/lib/src/data/streaming/streaming_response.dart
+++ b/lib/src/data/streaming/streaming_response.dart
@@ -249,7 +249,7 @@ sealed class ChannelStreamEvent with _$ChannelStreamEvent {
   @FreezedUnionValue("driveFileCreated")
   const factory ChannelStreamEvent.driveFileCreated({
     required String id,
-    required DriveFile driveFileCreated,
+    required DriveFile body,
   }) = DriveFileCreatedChannelEvent;
 
   @FreezedUnionValue("readAntenna")

--- a/lib/src/data/streaming/streaming_response.freezed.dart
+++ b/lib/src/data/streaming/streaming_response.freezed.dart
@@ -2342,8 +2342,7 @@ mixin _$ChannelStreamEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -2389,7 +2388,7 @@ mixin _$ChannelStreamEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -2433,7 +2432,7 @@ mixin _$ChannelStreamEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -2764,8 +2763,7 @@ class _$NoteChannelEventImpl implements NoteChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -2814,7 +2812,7 @@ class _$NoteChannelEventImpl implements NoteChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -2861,7 +2859,7 @@ class _$NoteChannelEventImpl implements NoteChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -3189,8 +3187,7 @@ class _$StatsLogChannelEventImpl implements StatsLogChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -3239,7 +3236,7 @@ class _$StatsLogChannelEventImpl implements StatsLogChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -3286,7 +3283,7 @@ class _$StatsLogChannelEventImpl implements StatsLogChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -3615,8 +3612,7 @@ class _$StatsChannelEventImpl implements StatsChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -3665,7 +3661,7 @@ class _$StatsChannelEventImpl implements StatsChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -3712,7 +3708,7 @@ class _$StatsChannelEventImpl implements StatsChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -4039,8 +4035,7 @@ class _$UserAddedChannelEventImpl implements UserAddedChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -4089,7 +4084,7 @@ class _$UserAddedChannelEventImpl implements UserAddedChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -4136,7 +4131,7 @@ class _$UserAddedChannelEventImpl implements UserAddedChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -4463,8 +4458,7 @@ class _$UserRemovedChannelEventImpl implements UserRemovedChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -4513,7 +4507,7 @@ class _$UserRemovedChannelEventImpl implements UserRemovedChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -4560,7 +4554,7 @@ class _$UserRemovedChannelEventImpl implements UserRemovedChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -4887,8 +4881,7 @@ class _$NotificationChannelEventImpl implements NotificationChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -4937,7 +4930,7 @@ class _$NotificationChannelEventImpl implements NotificationChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -4984,7 +4977,7 @@ class _$NotificationChannelEventImpl implements NotificationChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -5309,8 +5302,7 @@ class _$MentionChannelEventImpl implements MentionChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -5359,7 +5351,7 @@ class _$MentionChannelEventImpl implements MentionChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -5406,7 +5398,7 @@ class _$MentionChannelEventImpl implements MentionChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -5730,8 +5722,7 @@ class _$ReplyChannelEventImpl implements ReplyChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -5780,7 +5771,7 @@ class _$ReplyChannelEventImpl implements ReplyChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -5827,7 +5818,7 @@ class _$ReplyChannelEventImpl implements ReplyChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -6151,8 +6142,7 @@ class _$RenoteChannelEventImpl implements RenoteChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -6201,7 +6191,7 @@ class _$RenoteChannelEventImpl implements RenoteChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -6248,7 +6238,7 @@ class _$RenoteChannelEventImpl implements RenoteChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -6572,8 +6562,7 @@ class _$FollowChannelEventImpl implements FollowChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -6622,7 +6611,7 @@ class _$FollowChannelEventImpl implements FollowChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -6669,7 +6658,7 @@ class _$FollowChannelEventImpl implements FollowChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -6994,8 +6983,7 @@ class _$FollowedChannelEventImpl implements FollowedChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -7044,7 +7032,7 @@ class _$FollowedChannelEventImpl implements FollowedChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -7091,7 +7079,7 @@ class _$FollowedChannelEventImpl implements FollowedChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -7416,8 +7404,7 @@ class _$UnfollowChannelEventImpl implements UnfollowChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -7466,7 +7453,7 @@ class _$UnfollowChannelEventImpl implements UnfollowChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -7513,7 +7500,7 @@ class _$UnfollowChannelEventImpl implements UnfollowChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -7838,8 +7825,7 @@ class _$MeUpdatedChannelEventImpl implements MeUpdatedChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -7888,7 +7874,7 @@ class _$MeUpdatedChannelEventImpl implements MeUpdatedChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -7935,7 +7921,7 @@ class _$MeUpdatedChannelEventImpl implements MeUpdatedChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -8260,8 +8246,7 @@ class _$PageEventChannelEventImpl implements PageEventChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -8310,7 +8295,7 @@ class _$PageEventChannelEventImpl implements PageEventChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -8357,7 +8342,7 @@ class _$PageEventChannelEventImpl implements PageEventChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -8687,8 +8672,7 @@ class _$UrlUploadFinishedChannelEventImpl
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -8737,7 +8721,7 @@ class _$UrlUploadFinishedChannelEventImpl
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -8784,7 +8768,7 @@ class _$UrlUploadFinishedChannelEventImpl
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -9098,8 +9082,7 @@ class _$ReadAllNotificationsChannelEventImpl
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -9148,7 +9131,7 @@ class _$ReadAllNotificationsChannelEventImpl
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -9195,7 +9178,7 @@ class _$ReadAllNotificationsChannelEventImpl
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -9524,8 +9507,7 @@ class _$UnreadNotificationChannelEventImpl
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -9574,7 +9556,7 @@ class _$UnreadNotificationChannelEventImpl
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -9621,7 +9603,7 @@ class _$UnreadNotificationChannelEventImpl
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -9940,8 +9922,7 @@ class _$UnreadMentionChannelEventImpl implements UnreadMentionChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -9990,7 +9971,7 @@ class _$UnreadMentionChannelEventImpl implements UnreadMentionChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -10037,7 +10018,7 @@ class _$UnreadMentionChannelEventImpl implements UnreadMentionChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -10349,8 +10330,7 @@ class _$ReadAllUnreadMentionsChannelEventImpl
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -10399,7 +10379,7 @@ class _$ReadAllUnreadMentionsChannelEventImpl
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -10446,7 +10426,7 @@ class _$ReadAllUnreadMentionsChannelEventImpl
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -10758,8 +10738,7 @@ class _$NotificationFlushedChannelEventImpl
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -10808,7 +10787,7 @@ class _$NotificationFlushedChannelEventImpl
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -10855,7 +10834,7 @@ class _$NotificationFlushedChannelEventImpl
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -11174,8 +11153,7 @@ class _$UnreadSpecifiedNoteChannelEventImpl
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -11224,7 +11202,7 @@ class _$UnreadSpecifiedNoteChannelEventImpl
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -11271,7 +11249,7 @@ class _$UnreadSpecifiedNoteChannelEventImpl
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -11585,8 +11563,7 @@ class _$ReadAllUnreadSpecifiedNotesChannelEventImpl
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -11635,7 +11612,7 @@ class _$ReadAllUnreadSpecifiedNotesChannelEventImpl
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -11682,7 +11659,7 @@ class _$ReadAllUnreadSpecifiedNotesChannelEventImpl
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -11994,8 +11971,7 @@ class _$ReadAllAntennasChannelEventImpl implements ReadAllAntennasChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -12044,7 +12020,7 @@ class _$ReadAllAntennasChannelEventImpl implements ReadAllAntennasChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -12091,7 +12067,7 @@ class _$ReadAllAntennasChannelEventImpl implements ReadAllAntennasChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -12416,8 +12392,7 @@ class _$UnreadAntennaChannelEventImpl implements UnreadAntennaChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -12466,7 +12441,7 @@ class _$UnreadAntennaChannelEventImpl implements UnreadAntennaChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -12513,7 +12488,7 @@ class _$UnreadAntennaChannelEventImpl implements UnreadAntennaChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -12825,8 +12800,7 @@ class _$ReadAllAnnouncementsChannelEventImpl
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -12875,7 +12849,7 @@ class _$ReadAllAnnouncementsChannelEventImpl
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -12922,7 +12896,7 @@ class _$ReadAllAnnouncementsChannelEventImpl
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -13233,8 +13207,7 @@ class _$MyTokenRegeneratedChannelEventImpl
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -13283,7 +13256,7 @@ class _$MyTokenRegeneratedChannelEventImpl
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -13330,7 +13303,7 @@ class _$MyTokenRegeneratedChannelEventImpl
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -13653,8 +13626,7 @@ class _$SigninChannelEventImpl implements SigninChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -13703,7 +13675,7 @@ class _$SigninChannelEventImpl implements SigninChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -13750,7 +13722,7 @@ class _$SigninChannelEventImpl implements SigninChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -14078,8 +14050,7 @@ class _$RegistryUpdatedChannelEventImpl implements RegistryUpdatedChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -14128,7 +14099,7 @@ class _$RegistryUpdatedChannelEventImpl implements RegistryUpdatedChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -14175,7 +14146,7 @@ class _$RegistryUpdatedChannelEventImpl implements RegistryUpdatedChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -14377,9 +14348,9 @@ abstract class _$$DriveFileCreatedChannelEventImplCopyWith<$Res>
       __$$DriveFileCreatedChannelEventImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({String id, DriveFile driveFileCreated});
+  $Res call({String id, DriveFile body});
 
-  $DriveFileCopyWith<$Res> get driveFileCreated;
+  $DriveFileCopyWith<$Res> get body;
 }
 
 /// @nodoc
@@ -14396,25 +14367,25 @@ class __$$DriveFileCreatedChannelEventImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? id = null,
-    Object? driveFileCreated = null,
+    Object? body = null,
   }) {
     return _then(_$DriveFileCreatedChannelEventImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as String,
-      driveFileCreated: null == driveFileCreated
-          ? _value.driveFileCreated
-          : driveFileCreated // ignore: cast_nullable_to_non_nullable
+      body: null == body
+          ? _value.body
+          : body // ignore: cast_nullable_to_non_nullable
               as DriveFile,
     ));
   }
 
   @override
   @pragma('vm:prefer-inline')
-  $DriveFileCopyWith<$Res> get driveFileCreated {
-    return $DriveFileCopyWith<$Res>(_value.driveFileCreated, (value) {
-      return _then(_value.copyWith(driveFileCreated: value));
+  $DriveFileCopyWith<$Res> get body {
+    return $DriveFileCopyWith<$Res>(_value.body, (value) {
+      return _then(_value.copyWith(body: value));
     });
   }
 }
@@ -14424,7 +14395,7 @@ class __$$DriveFileCreatedChannelEventImplCopyWithImpl<$Res>
 class _$DriveFileCreatedChannelEventImpl
     implements DriveFileCreatedChannelEvent {
   const _$DriveFileCreatedChannelEventImpl(
-      {required this.id, required this.driveFileCreated, final String? $type})
+      {required this.id, required this.body, final String? $type})
       : $type = $type ?? 'driveFileCreated';
 
   factory _$DriveFileCreatedChannelEventImpl.fromJson(
@@ -14434,14 +14405,14 @@ class _$DriveFileCreatedChannelEventImpl
   @override
   final String id;
   @override
-  final DriveFile driveFileCreated;
+  final DriveFile body;
 
   @JsonKey(name: 'type')
   final String $type;
 
   @override
   String toString() {
-    return 'ChannelStreamEvent.driveFileCreated(id: $id, driveFileCreated: $driveFileCreated)';
+    return 'ChannelStreamEvent.driveFileCreated(id: $id, body: $body)';
   }
 
   @override
@@ -14450,13 +14421,12 @@ class _$DriveFileCreatedChannelEventImpl
         (other.runtimeType == runtimeType &&
             other is _$DriveFileCreatedChannelEventImpl &&
             (identical(other.id, id) || other.id == id) &&
-            (identical(other.driveFileCreated, driveFileCreated) ||
-                other.driveFileCreated == driveFileCreated));
+            (identical(other.body, body) || other.body == body));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, id, driveFileCreated);
+  int get hashCode => Object.hash(runtimeType, id, body);
 
   @JsonKey(ignore: true)
   @override
@@ -14506,15 +14476,14 @@ class _$DriveFileCreatedChannelEventImpl
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
         announcementCreated,
     required TResult Function(String id, Object? body) fallback,
   }) {
-    return driveFileCreated(id, this.driveFileCreated);
+    return driveFileCreated(id, body);
   }
 
   @override
@@ -14556,14 +14525,14 @@ class _$DriveFileCreatedChannelEventImpl
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
         announcementCreated,
     TResult? Function(String id, Object? body)? fallback,
   }) {
-    return driveFileCreated?.call(id, this.driveFileCreated);
+    return driveFileCreated?.call(id, body);
   }
 
   @override
@@ -14603,7 +14572,7 @@ class _$DriveFileCreatedChannelEventImpl
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -14612,7 +14581,7 @@ class _$DriveFileCreatedChannelEventImpl
     required TResult orElse(),
   }) {
     if (driveFileCreated != null) {
-      return driveFileCreated(id, this.driveFileCreated);
+      return driveFileCreated(id, body);
     }
     return orElse();
   }
@@ -14781,16 +14750,15 @@ class _$DriveFileCreatedChannelEventImpl
 
 abstract class DriveFileCreatedChannelEvent implements ChannelStreamEvent {
   const factory DriveFileCreatedChannelEvent(
-          {required final String id,
-          required final DriveFile driveFileCreated}) =
-      _$DriveFileCreatedChannelEventImpl;
+      {required final String id,
+      required final DriveFile body}) = _$DriveFileCreatedChannelEventImpl;
 
   factory DriveFileCreatedChannelEvent.fromJson(Map<String, dynamic> json) =
       _$DriveFileCreatedChannelEventImpl.fromJson;
 
   @override
   String get id;
-  DriveFile get driveFileCreated;
+  DriveFile get body;
   @override
   @JsonKey(ignore: true)
   _$$DriveFileCreatedChannelEventImplCopyWith<
@@ -14932,8 +14900,7 @@ class _$ReadAntennaChannelEventImpl implements ReadAntennaChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -14982,7 +14949,7 @@ class _$ReadAntennaChannelEventImpl implements ReadAntennaChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -15029,7 +14996,7 @@ class _$ReadAntennaChannelEventImpl implements ReadAntennaChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -15359,8 +15326,7 @@ class _$ReceiveFollowRequestChannelEventImpl
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -15409,7 +15375,7 @@ class _$ReceiveFollowRequestChannelEventImpl
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -15456,7 +15422,7 @@ class _$ReceiveFollowRequestChannelEventImpl
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -15787,8 +15753,7 @@ class _$AnnouncementCreatedChannelEventImpl
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -15837,7 +15802,7 @@ class _$AnnouncementCreatedChannelEventImpl
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -15884,7 +15849,7 @@ class _$AnnouncementCreatedChannelEventImpl
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -16199,8 +16164,7 @@ class _$FallbackChannelEventImpl implements FallbackChannelEvent {
     required TResult Function(String id) myTokenRegenerated,
     required TResult Function(String id, Signin body) signin,
     required TResult Function(String id, RegistryUpdated body) registryUpdated,
-    required TResult Function(String id, DriveFile driveFileCreated)
-        driveFileCreated,
+    required TResult Function(String id, DriveFile body) driveFileCreated,
     required TResult Function(String id, Antenna body) readAntenna,
     required TResult Function(String id, UserLite body) receiveFollowRequest,
     required TResult Function(String id, AnnouncementCreatedStreamEvent body)
@@ -16249,7 +16213,7 @@ class _$FallbackChannelEventImpl implements FallbackChannelEvent {
     TResult? Function(String id)? myTokenRegenerated,
     TResult? Function(String id, Signin body)? signin,
     TResult? Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult? Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult? Function(String id, DriveFile body)? driveFileCreated,
     TResult? Function(String id, Antenna body)? readAntenna,
     TResult? Function(String id, UserLite body)? receiveFollowRequest,
     TResult? Function(String id, AnnouncementCreatedStreamEvent body)?
@@ -16296,7 +16260,7 @@ class _$FallbackChannelEventImpl implements FallbackChannelEvent {
     TResult Function(String id)? myTokenRegenerated,
     TResult Function(String id, Signin body)? signin,
     TResult Function(String id, RegistryUpdated body)? registryUpdated,
-    TResult Function(String id, DriveFile driveFileCreated)? driveFileCreated,
+    TResult Function(String id, DriveFile body)? driveFileCreated,
     TResult Function(String id, Antenna body)? readAntenna,
     TResult Function(String id, UserLite body)? receiveFollowRequest,
     TResult Function(String id, AnnouncementCreatedStreamEvent body)?

--- a/lib/src/data/streaming/streaming_response.g.dart
+++ b/lib/src/data/streaming/streaming_response.g.dart
@@ -652,8 +652,7 @@ _$DriveFileCreatedChannelEventImpl _$$DriveFileCreatedChannelEventImplFromJson(
         Map<String, dynamic> json) =>
     _$DriveFileCreatedChannelEventImpl(
       id: json['id'] as String,
-      driveFileCreated:
-          DriveFile.fromJson(json['driveFileCreated'] as Map<String, dynamic>),
+      body: DriveFile.fromJson(json['body'] as Map<String, dynamic>),
       $type: json['type'] as String?,
     );
 
@@ -661,7 +660,7 @@ Map<String, dynamic> _$$DriveFileCreatedChannelEventImplToJson(
         _$DriveFileCreatedChannelEventImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
-      'driveFileCreated': instance.driveFileCreated.toJson(),
+      'body': instance.body.toJson(),
       'type': instance.$type,
     };
 

--- a/test/misskey_users_test.dart
+++ b/test/misskey_users_test.dart
@@ -115,13 +115,18 @@ void main() async {
     });
   });
 
-  test("search-by-username-and-host", () async {
-    final response = await userClient.users.searchByUsernameAndHost(
-      UsersSearchByUsernameAndHostRequest(username: user.username, host: "."),
-    );
-    expect(response.map((e) => e.id), contains(user.id));
-    expect(response, everyElement(isA<UserDetailed>()));
-  });
+  test(
+    "search-by-username-and-host",
+    () async {
+      await userClient.createNote();
+      final response = await userClient.users.searchByUsernameAndHost(
+        UsersSearchByUsernameAndHostRequest(username: user.username, host: "."),
+      );
+      expect(response.map((e) => e.id), contains(user.id));
+      expect(response, everyElement(isA<UserDetailed>()));
+    },
+    retry: 3,
+  );
 
   test(
     "recommendation",

--- a/test/streaming_test.dart
+++ b/test/streaming_test.dart
@@ -508,7 +508,11 @@ void main() async {
           final id = DateTime.now().toIso8601String();
           final listener = controller.mainStream(id: id).listen((event) {
             final body = event.body;
-            if (body is ReadAllAnnouncementsChannelEvent) completer.complete();
+            if (body is ReadAllAnnouncementsChannelEvent) {
+              if (!completer.isCompleted) {
+                completer.complete();
+              }
+            }
           });
           await Future.wait(
             announcements.map((announcement) {

--- a/test/streaming_test.dart
+++ b/test/streaming_test.dart
@@ -523,6 +523,23 @@ void main() async {
           await completer.future;
           await (controller.removeChannel(id), listener.cancel()).wait;
         });
+
+        test("driveFileCreated", () async {
+          final completer = Completer<DriveFile>();
+          final client = userClient;
+
+          final controller = await client.streamingService.stream();
+          final id = DateTime.now().toIso8601String();
+          final listener = controller.mainStream(id: id).listen((event) {
+            final body = event.body;
+            if (body is DriveFileCreatedChannelEvent) {
+              completer.complete(body.body);
+            }
+          });
+          await client.createDriveFile();
+          await completer.future;
+          await (controller.removeChannel(id), listener.cancel()).wait;
+        });
       });
     },
     retry: 3,


### PR DESCRIPTION
- `DriveFileCreatedChannelEvent` の `body` が `driveFileCreated` になっていた問題を修正しました
- `readAllAnnouncements` のテストが Completer の `complete` が複数回呼ばれていることが原因で失敗している問題を修正しました
- 不安定な `search-by-username-and-host` のテストをリトライするようにしました