### PR TITLE
テスト時の絵文字のファイルを画像にする

### DIFF
--- a/test/streaming_test.dart
+++ b/test/streaming_test.dart
@@ -626,7 +626,7 @@ void main() async {
       final completer = Completer<Emoji>();
       final client = userClient;
       final name = Uuid().v4().replaceAll("-", "_");
-      final file = await adminClient.createDriveFile();
+      final file = await adminClient.createImageDriveFile();
       final controller = await client.streamingService.stream();
       final id = DateTime.now().toIso8601String();
       final listener = controller
@@ -644,7 +644,7 @@ void main() async {
     test("emojiUpdated", () async {
       final completer = Completer<Iterable<Emoji>>();
       final client = userClient;
-      final file = await adminClient.createDriveFile();
+      final file = await adminClient.createImageDriveFile();
       final name = Uuid().v4().replaceAll("-", "_");
       final response = await adminClient.apiService
           .post("admin/emoji/add", {"name": name, "fileId": file.id});
@@ -671,7 +671,7 @@ void main() async {
     test("emojiDeleted", () async {
       final completer = Completer<Iterable<Emoji>>();
       final client = userClient;
-      final file = await adminClient.createDriveFile();
+      final file = await adminClient.createImageDriveFile();
       final name = Uuid().v4().replaceAll("-", "_");
       final response = await adminClient.apiService
           .post("admin/emoji/add", {"name": name, "fileId": file.id});

--- a/test/util/misskey_dart_test_util.dart
+++ b/test/util/misskey_dart_test_util.dart
@@ -80,6 +80,22 @@ extension MisskeyTestExtension on Misskey {
     );
   }
 
+  Future<DriveFile> createImageDriveFile() async {
+    return drive.files.createAsBinary(
+      DriveFilesCreateRequest(force: true),
+      Uint8List.fromList(
+        [
+          // header
+          ..."GIF89a".codeUnits, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+          // image block
+          0x2c, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00,
+          // trailer
+          0x3b,
+        ],
+      ),
+    );
+  }
+
   Future<Map<String, dynamic>> createPage() {
     return apiService.post<Map<String, dynamic>>("pages/create", {
       "title": "test",


### PR DESCRIPTION
`misskey-dev/misskey#13473` で画像以外のファイルを絵文字に追加できなくなりました
これによって絵文字関連のストリーミングのテストが落ちるようになったので、絵文字追加時は画像ファイルを利用するように変更しました

ref: https://github.com/misskey-dev/misskey/pull/13473/files#diff-53e29b550b07476229cd9776431782a5f0afc3b9f29e8bbd67041e24aa5bd307R90