### PR TITLE
formatの前にpub getを実行する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
+      - run: dart pub get
       - run: dart format --output=none --set-exit-if-changed .
   analyze:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Dart 3.7.0 で導入された新しいスタイルでフォーマットされることを防ぐために、CIでフォーマットを行う前に `pub get` を実行するようにしました