### PR TITLE
ノートの既読関連のテストをスキップ

### DIFF
--- a/lib/src/data/streaming/streaming_response.dart
+++ b/lib/src/data/streaming/streaming_response.dart
@@ -186,12 +186,14 @@ sealed class ChannelStreamEvent with _$ChannelStreamEvent {
     required INotificationsResponse body,
   }) = UnreadNotificationChannelEvent;
 
+  /// Removed in Misskey 2025.3.2-beta.10.
   @FreezedUnionValue("unreadMention")
   const factory ChannelStreamEvent.unreadMention({
     required String id,
     required String body,
   }) = UnreadMentionChannelEvent;
 
+  /// Removed in Misskey 2025.3.2-beta.10.
   @FreezedUnionValue("readAllUnreadMentions")
   const factory ChannelStreamEvent.readAllUnreadMentions({
     required String id,
@@ -202,17 +204,20 @@ sealed class ChannelStreamEvent with _$ChannelStreamEvent {
     required String id,
   }) = NotificationFlushedChannelEvent;
 
+  /// Removed in Misskey 2025.3.2-beta.10.
   @FreezedUnionValue("unreadSpecifiedNote")
   const factory ChannelStreamEvent.unreadSpecifiedNote({
     required String id,
     required String body,
   }) = UnreadSpecifiedNoteChannelEvent;
 
+  /// Removed in Misskey 2025.3.2-beta.10.
   @FreezedUnionValue("readAllUnreadSpecifiedNotes")
   const factory ChannelStreamEvent.readAllUnreadSpecifiedNotes({
     required String id,
   }) = ReadAllUnreadSpecifiedNotesChannelEvent;
 
+  /// Removed in Misskey 2025.3.2-beta.10.
   @FreezedUnionValue("readAllAntennas")
   const factory ChannelStreamEvent.readAllAntennas({
     required String id,

--- a/test/streaming_test.dart
+++ b/test/streaming_test.dart
@@ -399,79 +399,95 @@ void main() async {
           await (controller.removeChannel(id), listener.cancel()).wait;
         });
 
-        test("unreadMention", () async {
-          final completer = Completer<String>();
-          final client = userClient;
-          final controller = await client.streamingService.stream();
-          final id = DateTime.now().toIso8601String();
-          final listener = controller.mainStream(id: id).listen((event) {
-            final body = event.body;
-            if (body is UnreadMentionChannelEvent) {
-              completer.complete(body.body);
-            }
-          });
-          await adminClient.notes
-              .create(NotesCreateRequest(text: "@${user.username}"));
-          await completer.future;
-          await (controller.removeChannel(id), listener.cancel()).wait;
-        });
+        test(
+          "unreadMention",
+          () async {
+            final completer = Completer<String>();
+            final client = userClient;
+            final controller = await client.streamingService.stream();
+            final id = DateTime.now().toIso8601String();
+            final listener = controller.mainStream(id: id).listen((event) {
+              final body = event.body;
+              if (body is UnreadMentionChannelEvent) {
+                completer.complete(body.body);
+              }
+            });
+            await adminClient.notes
+                .create(NotesCreateRequest(text: "@${user.username}"));
+            await completer.future;
+            await (controller.removeChannel(id), listener.cancel()).wait;
+          },
+          skip: "removed in Misskey 2025.3.2-beta.10",
+        );
 
-        test("readAllUnreadMentions", () async {
-          final completer = Completer<void>();
-          final client = userClient;
+        test(
+          "readAllUnreadMentions",
+          () async {
+            final completer = Completer<void>();
+            final client = userClient;
 
-          final controller = await client.streamingService.stream();
-          final id = DateTime.now().toIso8601String();
-          final listener = controller.mainStream(id: id).listen((event) {
-            final body = event.body;
-            if (body is ReadAllUnreadMentionsChannelEvent) {
-              completer.complete();
-            }
-          });
-          await client.apiService.post("i/read-all-unread-notes", {});
-          await completer.future;
-          await (controller.removeChannel(id), listener.cancel()).wait;
-        });
+            final controller = await client.streamingService.stream();
+            final id = DateTime.now().toIso8601String();
+            final listener = controller.mainStream(id: id).listen((event) {
+              final body = event.body;
+              if (body is ReadAllUnreadMentionsChannelEvent) {
+                completer.complete();
+              }
+            });
+            await client.apiService.post("i/read-all-unread-notes", {});
+            await completer.future;
+            await (controller.removeChannel(id), listener.cancel()).wait;
+          },
+          skip: "removed in Misskey 2025.3.2-beta.10",
+        );
 
-        test("unreadSpecifiedNote", () async {
-          final completer = Completer<String>();
-          final client = userClient;
+        test(
+          "unreadSpecifiedNote",
+          () async {
+            final completer = Completer<String>();
+            final client = userClient;
 
-          final controller = await client.streamingService.stream();
-          final id = DateTime.now().toIso8601String();
-          final listener = controller.mainStream(id: id).listen((event) {
-            final body = event.body;
-            if (body is UnreadSpecifiedNoteChannelEvent) {
-              completer.complete(body.body);
-            }
-          });
-          await adminClient.notes.create(
-            NotesCreateRequest(
-              visibility: NoteVisibility.specified,
-              visibleUserIds: [user.id],
-              text: "specified note",
-            ),
-          );
-          await completer.future;
-          await (controller.removeChannel(id), listener.cancel()).wait;
-        });
+            final controller = await client.streamingService.stream();
+            final id = DateTime.now().toIso8601String();
+            final listener = controller.mainStream(id: id).listen((event) {
+              final body = event.body;
+              if (body is UnreadSpecifiedNoteChannelEvent) {
+                completer.complete(body.body);
+              }
+            });
+            await adminClient.notes.create(
+              NotesCreateRequest(
+                visibility: NoteVisibility.specified,
+                visibleUserIds: [user.id],
+                text: "specified note",
+              ),
+            );
+            await completer.future;
+            await (controller.removeChannel(id), listener.cancel()).wait;
+          },
+          skip: "removed in Misskey 2025.3.2-beta.10",
+        );
 
-        test("readAllUnreadSpecifiedNotes", () async {
-          final completer = Completer<void>();
-          final client = userClient;
+        test(
+          "readAllUnreadSpecifiedNotes",
+          () async {
+            final completer = Completer<void>();
+            final client = userClient;
 
-          final controller = await client.streamingService.stream();
-          final id = DateTime.now().toIso8601String();
-          final listener = controller.mainStream(id: id).listen((event) {
-            final body = event.body;
-            if (body is ReadAllUnreadSpecifiedNotesChannelEvent) {
-              completer.complete();
-            }
-          });
-          await client.apiService.post("i/read-all-unread-notes", {});
-          await completer.future;
-          await (controller.removeChannel(id), listener.cancel()).wait;
-        });
+            final controller = await client.streamingService.stream();
+            final id = DateTime.now().toIso8601String();
+            final listener = controller.mainStream(id: id).listen((event) {
+              final body = event.body;
+              if (body is ReadAllUnreadSpecifiedNotesChannelEvent) {
+                completer.complete();
+              }
+            });
+            await client.apiService.post("i/read-all-unread-notes", {});
+            await completer.future;
+            await (controller.removeChannel(id), listener.cancel()).wait;
+          },
+          skip: "removed in Misskey 2025.3.2-beta.10",
+        );
 
         test("receiveFollowRequest", () async {
           final completer = Completer<UserLite>();


### PR DESCRIPTION
Misskey 2025.3.2-beta.10で `main` のストリーミングイベントのうち、`unreadMention`, `readAllUnreadMentions`, `unreadSpecifiedNote`, `readAllUnreadSpecifiedNotes`, `readAllAntennas` が削除されたため、これらに関係するテストをスキップするようにしました

ref: https://github.com/misskey-dev/misskey/pull/15686/files#diff-45b5a56832e490b2930f880edbb514d81c58a9a165853cd8f1f24b4a453fd6fbL75-L79