### PR TITLE
Fix birthday field validation for Misskey API compatibility

### DIFF
--- a/lib/src/converters/date_time_converter.dart
+++ b/lib/src/converters/date_time_converter.dart
@@ -62,3 +62,17 @@ class NullableEpocTimeDateTimeConverter extends JsonConverter<DateTime?, int?> {
           ? object.microsecondsSinceEpoch
           : object.millisecondsSinceEpoch;
 }
+
+class BirthdayConverter extends JsonConverter<DateTime?, String?> {
+  const BirthdayConverter();
+
+  @override
+  DateTime? fromJson(String? json) => json == null ? null : DateTime.tryParse(json);
+
+  @override
+  String? toJson(DateTime? object) {
+    if (object == null) return null;
+    // YYYY-MM-DD形式で出力（Misskeyのバリデーション要件に合わせる）
+    return '${object.year.toString().padLeft(4, '0')}-${object.month.toString().padLeft(2, '0')}-${object.day.toString().padLeft(2, '0')}';
+  }
+}

--- a/lib/src/data/i/i_update_request.dart
+++ b/lib/src/data/i/i_update_request.dart
@@ -14,7 +14,7 @@ abstract class IUpdateRequest with _$IUpdateRequest {
     String? description,
     String? followedMessage,
     String? location,
-    @DateTimeConverter() DateTime? birthday,
+    @BirthdayConverter() DateTime? birthday,
     String? lang,
     String? avatarId,
     List<IUpdateAvatarDecoration>? avatarDecorations,


### PR DESCRIPTION
- Add BirthdayConverter to format DateTime as YYYY-MM-DD string
- Replace DateTimeConverter with BirthdayConverter for IUpdateRequest.birthday
- Ensure compatibility with Misskey's birthday field validation pattern: `^([0-9]{4})-([0-9]{2})-([0-9]{2})$`

🤖 Generated with [Claude Code](https://claude.ai/code)