### PR TITLE
AntennasNotesRequestでEpocTimeDateTimeConverterを使うように

### DIFF
--- a/lib/src/data/antennas/antennas_notes_request.dart
+++ b/lib/src/data/antennas/antennas_notes_request.dart
@@ -11,8 +11,8 @@ abstract class AntennasNotesRequest with _$AntennasNotesRequest {
     int? limit,
     String? sinceId,
     String? untilId,
-    @DateTimeConverter() DateTime? sinceDate,
-    @DateTimeConverter() DateTime? untilDate,
+    @EpocTimeDateTimeConverter.withMilliSeconds() DateTime? sinceDate,
+    @EpocTimeDateTimeConverter.withMilliSeconds() DateTime? untilDate,
   }) = _AntennasNotesRequest;
 
   factory AntennasNotesRequest.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/data/antennas/antennas_notes_request.freezed.dart
+++ b/lib/src/data/antennas/antennas_notes_request.freezed.dart
@@ -19,9 +19,9 @@ mixin _$AntennasNotesRequest {
   int? get limit;
   String? get sinceId;
   String? get untilId;
-  @DateTimeConverter()
+  @EpocTimeDateTimeConverter.withMilliSeconds()
   DateTime? get sinceDate;
-  @DateTimeConverter()
+  @EpocTimeDateTimeConverter.withMilliSeconds()
   DateTime? get untilDate;
 
   /// Create a copy of AntennasNotesRequest
@@ -73,8 +73,8 @@ abstract mixin class $AntennasNotesRequestCopyWith<$Res> {
       int? limit,
       String? sinceId,
       String? untilId,
-      @DateTimeConverter() DateTime? sinceDate,
-      @DateTimeConverter() DateTime? untilDate});
+      @EpocTimeDateTimeConverter.withMilliSeconds() DateTime? sinceDate,
+      @EpocTimeDateTimeConverter.withMilliSeconds() DateTime? untilDate});
 }
 
 /// @nodoc
@@ -134,8 +134,8 @@ class _AntennasNotesRequest implements AntennasNotesRequest {
       this.limit,
       this.sinceId,
       this.untilId,
-      @DateTimeConverter() this.sinceDate,
-      @DateTimeConverter() this.untilDate});
+      @EpocTimeDateTimeConverter.withMilliSeconds() this.sinceDate,
+      @EpocTimeDateTimeConverter.withMilliSeconds() this.untilDate});
   factory _AntennasNotesRequest.fromJson(Map<String, dynamic> json) =>
       _$AntennasNotesRequestFromJson(json);
 
@@ -148,10 +148,10 @@ class _AntennasNotesRequest implements AntennasNotesRequest {
   @override
   final String? untilId;
   @override
-  @DateTimeConverter()
+  @EpocTimeDateTimeConverter.withMilliSeconds()
   final DateTime? sinceDate;
   @override
-  @DateTimeConverter()
+  @EpocTimeDateTimeConverter.withMilliSeconds()
   final DateTime? untilDate;
 
   /// Create a copy of AntennasNotesRequest
@@ -210,8 +210,8 @@ abstract mixin class _$AntennasNotesRequestCopyWith<$Res>
       int? limit,
       String? sinceId,
       String? untilId,
-      @DateTimeConverter() DateTime? sinceDate,
-      @DateTimeConverter() DateTime? untilDate});
+      @EpocTimeDateTimeConverter.withMilliSeconds() DateTime? sinceDate,
+      @EpocTimeDateTimeConverter.withMilliSeconds() DateTime? untilDate});
 }
 
 /// @nodoc

--- a/lib/src/data/antennas/antennas_notes_request.g.dart
+++ b/lib/src/data/antennas/antennas_notes_request.g.dart
@@ -13,10 +13,10 @@ _AntennasNotesRequest _$AntennasNotesRequestFromJson(
       limit: (json['limit'] as num?)?.toInt(),
       sinceId: json['sinceId'] as String?,
       untilId: json['untilId'] as String?,
-      sinceDate: _$JsonConverterFromJson<String, DateTime>(
-          json['sinceDate'], const DateTimeConverter().fromJson),
-      untilDate: _$JsonConverterFromJson<String, DateTime>(
-          json['untilDate'], const DateTimeConverter().fromJson),
+      sinceDate: _$JsonConverterFromJson<int, DateTime>(json['sinceDate'],
+          const EpocTimeDateTimeConverter.withMilliSeconds().fromJson),
+      untilDate: _$JsonConverterFromJson<int, DateTime>(json['untilDate'],
+          const EpocTimeDateTimeConverter.withMilliSeconds().fromJson),
     );
 
 Map<String, dynamic> _$AntennasNotesRequestToJson(
@@ -26,10 +26,10 @@ Map<String, dynamic> _$AntennasNotesRequestToJson(
       'limit': instance.limit,
       'sinceId': instance.sinceId,
       'untilId': instance.untilId,
-      'sinceDate': _$JsonConverterToJson<String, DateTime>(
-          instance.sinceDate, const DateTimeConverter().toJson),
-      'untilDate': _$JsonConverterToJson<String, DateTime>(
-          instance.untilDate, const DateTimeConverter().toJson),
+      'sinceDate': _$JsonConverterToJson<int, DateTime>(instance.sinceDate,
+          const EpocTimeDateTimeConverter.withMilliSeconds().toJson),
+      'untilDate': _$JsonConverterToJson<int, DateTime>(instance.untilDate,
+          const EpocTimeDateTimeConverter.withMilliSeconds().toJson),
     };
 
 Value? _$JsonConverterFromJson<Json, Value>(


### PR DESCRIPTION
`AntennasNotesRequest` の `sinceDate` と `untilDate` が文字列に変換されていたのをタイムスタンプにするように修正しました

ref: https://github.com/misskey-dev/misskey/blob/2025.7.0/packages/backend/src/server/api/endpoints/antennas/notes.ts#L52-L53