### PR TITLE
testenv作成時に連合を有効にする

### DIFF
--- a/test/testenv/get-token/get-token.sh
+++ b/test/testenv/get-token/get-token.sh
@@ -13,8 +13,12 @@ ADMIN_DATA=$(
 ADMIN_TOKEN=$(echo "$ADMIN_DATA" | jq -r .token)
 ADMIN_ID=$(echo "$ADMIN_DATA" | jq -r .id)
 
-curl -fsS -XPOST -H 'Content-Type: application/json'                \
-  --data '{"i": "'"${ADMIN_TOKEN}"'","disableRegistration": false}' \
+curl -fsS -XPOST -H 'Content-Type: application/json' \
+  --data '{
+      "i": "'"${ADMIN_TOKEN}"'",
+      "disableRegistration": false,
+      "federation": "all"
+    }' \
   http://web:3000/api/admin/update-meta
 
 USER_DATA=$(


### PR DESCRIPTION
https://github.com/misskey-dev/misskey/commit/b2b07e5f21f10faa59ce60bec788306438415b65 でサーバー作成時にデフォルトで連合がオフになるようになりました
これによって `ap/show` のテストが落ちるようになったのでサーバー作成時に連合を有効にするようにしました