### PR TITLE
CI=trueを指定

### DIFF
--- a/test/testenv/compose.yml
+++ b/test/testenv/compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   get-token:
     build: get-token

--- a/test/testenv/compose.yml
+++ b/test/testenv/compose.yml
@@ -27,6 +27,7 @@ services:
     volumes:
       - ./.config:/misskey/.config
     environment:
+      - CI=true
       - NODE_ENV=development
 
   redis:


### PR DESCRIPTION
[misskey-dev/misskey#17400](https://redirect.github.com/misskey-dev/misskey/pull/17400) でpnpmのバージョンが上がった後から、developでテストを実行しようとすると [pnpm/pnpm#9966](https://redirect.github.com/pnpm/pnpm/issues/9966) のエラーが発生するようになりました
`CI=true` を与えることでこの問題を解消しました

ついでにdocker-compose.ymlをcompose.ymlにしてversionも消しました