### PR TITLE
feat(notes): notes/search の rangeStartAt / rangeEndAt に対応する

### DIFF
--- a/lib/src/data/notes/notes_search_request.dart
+++ b/lib/src/data/notes/notes_search_request.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:misskey_dart/src/converters/date_time_converter.dart';
 
 part 'notes_search_request.freezed.dart';
 part 'notes_search_request.g.dart';
@@ -14,6 +15,15 @@ abstract class NotesSearchRequest with _$NotesSearchRequest {
 
     /// 指定すると、idがその値よりも小さいノートを返します。
     String? untilId,
+
+    /// 指定すると、その日時以降に投稿されたノートに絞り込みます。
+    ///
+    /// `sinceId` / `untilId` はページングのカーソルなので、投稿日時で
+    /// 絞り込むときはこちらを使います。
+    @EpocTimeDateTimeConverter.withMilliSeconds() DateTime? rangeStartAt,
+
+    /// 指定すると、その日時以前に投稿されたノートに絞り込みます。
+    @EpocTimeDateTimeConverter.withMilliSeconds() DateTime? rangeEndAt,
 
     /// 取得するノートの最大数。
     int? limit,

--- a/lib/src/data/notes/notes_search_request.freezed.dart
+++ b/lib/src/data/notes/notes_search_request.freezed.dart
@@ -15,85 +15,60 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$NotesSearchRequest {
-  /// 検索クエリ。クエリが本文に含まれるノートを検索します。
-  String get query;
 
-  /// 指定すると、idがその値よりも大きいノートを返します。
-  String? get sinceId;
-
-  /// 指定すると、idがその値よりも小さいノートを返します。
-  String? get untilId;
-
-  /// 取得するノートの最大数。
-  int? get limit;
-
-  /// 検索結果の先頭offset個をスキップします。
-  int? get offset;
-
-  /// The local host is represented with `null`.
-  String? get host;
-
-  /// 指定すると、そのユーザが作成したノートを検索します。
-  String? get userId;
-
-  /// 指定すると、そのチャンネルに属するノートを検索します。userIdと併せて指定した場合、channelIdは無視されます。
-  String? get channelId;
-
-  /// Create a copy of NotesSearchRequest
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $NotesSearchRequestCopyWith<NotesSearchRequest> get copyWith =>
-      _$NotesSearchRequestCopyWithImpl<NotesSearchRequest>(
-          this as NotesSearchRequest, _$identity);
+/// 検索クエリ。クエリが本文に含まれるノートを検索します。
+ String get query;/// 指定すると、idがその値よりも大きいノートを返します。
+ String? get sinceId;/// 指定すると、idがその値よりも小さいノートを返します。
+ String? get untilId;/// 指定すると、その日時以降に投稿されたノートに絞り込みます。
+///
+/// `sinceId` / `untilId` はページングのカーソルなので、投稿日時で
+/// 絞り込むときはこちらを使います。
+@EpocTimeDateTimeConverter.withMilliSeconds() DateTime? get rangeStartAt;/// 指定すると、その日時以前に投稿されたノートに絞り込みます。
+@EpocTimeDateTimeConverter.withMilliSeconds() DateTime? get rangeEndAt;/// 取得するノートの最大数。
+ int? get limit;/// 検索結果の先頭offset個をスキップします。
+ int? get offset;/// The local host is represented with `null`.
+ String? get host;/// 指定すると、そのユーザが作成したノートを検索します。
+ String? get userId;/// 指定すると、そのチャンネルに属するノートを検索します。userIdと併せて指定した場合、channelIdは無視されます。
+ String? get channelId;
+/// Create a copy of NotesSearchRequest
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$NotesSearchRequestCopyWith<NotesSearchRequest> get copyWith => _$NotesSearchRequestCopyWithImpl<NotesSearchRequest>(this as NotesSearchRequest, _$identity);
 
   /// Serializes this NotesSearchRequest to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is NotesSearchRequest &&
-            (identical(other.query, query) || other.query == query) &&
-            (identical(other.sinceId, sinceId) || other.sinceId == sinceId) &&
-            (identical(other.untilId, untilId) || other.untilId == untilId) &&
-            (identical(other.limit, limit) || other.limit == limit) &&
-            (identical(other.offset, offset) || other.offset == offset) &&
-            (identical(other.host, host) || other.host == host) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.channelId, channelId) ||
-                other.channelId == channelId));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, query, sinceId, untilId, limit,
-      offset, host, userId, channelId);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotesSearchRequest&&(identical(other.query, query) || other.query == query)&&(identical(other.sinceId, sinceId) || other.sinceId == sinceId)&&(identical(other.untilId, untilId) || other.untilId == untilId)&&(identical(other.rangeStartAt, rangeStartAt) || other.rangeStartAt == rangeStartAt)&&(identical(other.rangeEndAt, rangeEndAt) || other.rangeEndAt == rangeEndAt)&&(identical(other.limit, limit) || other.limit == limit)&&(identical(other.offset, offset) || other.offset == offset)&&(identical(other.host, host) || other.host == host)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.channelId, channelId) || other.channelId == channelId));
+}
 
-  @override
-  String toString() {
-    return 'NotesSearchRequest(query: $query, sinceId: $sinceId, untilId: $untilId, limit: $limit, offset: $offset, host: $host, userId: $userId, channelId: $channelId)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,query,sinceId,untilId,rangeStartAt,rangeEndAt,limit,offset,host,userId,channelId);
+
+@override
+String toString() {
+  return 'NotesSearchRequest(query: $query, sinceId: $sinceId, untilId: $untilId, rangeStartAt: $rangeStartAt, rangeEndAt: $rangeEndAt, limit: $limit, offset: $offset, host: $host, userId: $userId, channelId: $channelId)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $NotesSearchRequestCopyWith<$Res> {
-  factory $NotesSearchRequestCopyWith(
-          NotesSearchRequest value, $Res Function(NotesSearchRequest) _then) =
-      _$NotesSearchRequestCopyWithImpl;
-  @useResult
-  $Res call(
-      {String query,
-      String? sinceId,
-      String? untilId,
-      int? limit,
-      int? offset,
-      String? host,
-      String? userId,
-      String? channelId});
-}
+abstract mixin class $NotesSearchRequestCopyWith<$Res>  {
+  factory $NotesSearchRequestCopyWith(NotesSearchRequest value, $Res Function(NotesSearchRequest) _then) = _$NotesSearchRequestCopyWithImpl;
+@useResult
+$Res call({
+ String query, String? sinceId, String? untilId,@EpocTimeDateTimeConverter.withMilliSeconds() DateTime? rangeStartAt,@EpocTimeDateTimeConverter.withMilliSeconds() DateTime? rangeEndAt, int? limit, int? offset, String? host, String? userId, String? channelId
+});
 
+
+
+
+}
 /// @nodoc
 class _$NotesSearchRequestCopyWithImpl<$Res>
     implements $NotesSearchRequestCopyWith<$Res> {
@@ -102,165 +77,98 @@ class _$NotesSearchRequestCopyWithImpl<$Res>
   final NotesSearchRequest _self;
   final $Res Function(NotesSearchRequest) _then;
 
-  /// Create a copy of NotesSearchRequest
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? query = null,
-    Object? sinceId = freezed,
-    Object? untilId = freezed,
-    Object? limit = freezed,
-    Object? offset = freezed,
-    Object? host = freezed,
-    Object? userId = freezed,
-    Object? channelId = freezed,
-  }) {
-    return _then(_self.copyWith(
-      query: null == query
-          ? _self.query
-          : query // ignore: cast_nullable_to_non_nullable
-              as String,
-      sinceId: freezed == sinceId
-          ? _self.sinceId
-          : sinceId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      untilId: freezed == untilId
-          ? _self.untilId
-          : untilId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      limit: freezed == limit
-          ? _self.limit
-          : limit // ignore: cast_nullable_to_non_nullable
-              as int?,
-      offset: freezed == offset
-          ? _self.offset
-          : offset // ignore: cast_nullable_to_non_nullable
-              as int?,
-      host: freezed == host
-          ? _self.host
-          : host // ignore: cast_nullable_to_non_nullable
-              as String?,
-      userId: freezed == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      channelId: freezed == channelId
-          ? _self.channelId
-          : channelId // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Create a copy of NotesSearchRequest
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? query = null,Object? sinceId = freezed,Object? untilId = freezed,Object? rangeStartAt = freezed,Object? rangeEndAt = freezed,Object? limit = freezed,Object? offset = freezed,Object? host = freezed,Object? userId = freezed,Object? channelId = freezed,}) {
+  return _then(_self.copyWith(
+query: null == query ? _self.query : query // ignore: cast_nullable_to_non_nullable
+as String,sinceId: freezed == sinceId ? _self.sinceId : sinceId // ignore: cast_nullable_to_non_nullable
+as String?,untilId: freezed == untilId ? _self.untilId : untilId // ignore: cast_nullable_to_non_nullable
+as String?,rangeStartAt: freezed == rangeStartAt ? _self.rangeStartAt : rangeStartAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,rangeEndAt: freezed == rangeEndAt ? _self.rangeEndAt : rangeEndAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,limit: freezed == limit ? _self.limit : limit // ignore: cast_nullable_to_non_nullable
+as int?,offset: freezed == offset ? _self.offset : offset // ignore: cast_nullable_to_non_nullable
+as int?,host: freezed == host ? _self.host : host // ignore: cast_nullable_to_non_nullable
+as String?,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String?,channelId: freezed == channelId ? _self.channelId : channelId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
+
+}
+
 
 /// @nodoc
 @JsonSerializable()
+
 class _NotesSearchRequest implements NotesSearchRequest {
-  const _NotesSearchRequest(
-      {required this.query,
-      this.sinceId,
-      this.untilId,
-      this.limit,
-      this.offset,
-      this.host,
-      this.userId,
-      this.channelId});
-  factory _NotesSearchRequest.fromJson(Map<String, dynamic> json) =>
-      _$NotesSearchRequestFromJson(json);
+  const _NotesSearchRequest({required this.query, this.sinceId, this.untilId, @EpocTimeDateTimeConverter.withMilliSeconds() this.rangeStartAt, @EpocTimeDateTimeConverter.withMilliSeconds() this.rangeEndAt, this.limit, this.offset, this.host, this.userId, this.channelId});
+  factory _NotesSearchRequest.fromJson(Map<String, dynamic> json) => _$NotesSearchRequestFromJson(json);
 
-  /// 検索クエリ。クエリが本文に含まれるノートを検索します。
-  @override
-  final String query;
+/// 検索クエリ。クエリが本文に含まれるノートを検索します。
+@override final  String query;
+/// 指定すると、idがその値よりも大きいノートを返します。
+@override final  String? sinceId;
+/// 指定すると、idがその値よりも小さいノートを返します。
+@override final  String? untilId;
+/// 指定すると、その日時以降に投稿されたノートに絞り込みます。
+///
+/// `sinceId` / `untilId` はページングのカーソルなので、投稿日時で
+/// 絞り込むときはこちらを使います。
+@override@EpocTimeDateTimeConverter.withMilliSeconds() final  DateTime? rangeStartAt;
+/// 指定すると、その日時以前に投稿されたノートに絞り込みます。
+@override@EpocTimeDateTimeConverter.withMilliSeconds() final  DateTime? rangeEndAt;
+/// 取得するノートの最大数。
+@override final  int? limit;
+/// 検索結果の先頭offset個をスキップします。
+@override final  int? offset;
+/// The local host is represented with `null`.
+@override final  String? host;
+/// 指定すると、そのユーザが作成したノートを検索します。
+@override final  String? userId;
+/// 指定すると、そのチャンネルに属するノートを検索します。userIdと併せて指定した場合、channelIdは無視されます。
+@override final  String? channelId;
 
-  /// 指定すると、idがその値よりも大きいノートを返します。
-  @override
-  final String? sinceId;
+/// Create a copy of NotesSearchRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$NotesSearchRequestCopyWith<_NotesSearchRequest> get copyWith => __$NotesSearchRequestCopyWithImpl<_NotesSearchRequest>(this, _$identity);
 
-  /// 指定すると、idがその値よりも小さいノートを返します。
-  @override
-  final String? untilId;
+@override
+Map<String, dynamic> toJson() {
+  return _$NotesSearchRequestToJson(this, );
+}
 
-  /// 取得するノートの最大数。
-  @override
-  final int? limit;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotesSearchRequest&&(identical(other.query, query) || other.query == query)&&(identical(other.sinceId, sinceId) || other.sinceId == sinceId)&&(identical(other.untilId, untilId) || other.untilId == untilId)&&(identical(other.rangeStartAt, rangeStartAt) || other.rangeStartAt == rangeStartAt)&&(identical(other.rangeEndAt, rangeEndAt) || other.rangeEndAt == rangeEndAt)&&(identical(other.limit, limit) || other.limit == limit)&&(identical(other.offset, offset) || other.offset == offset)&&(identical(other.host, host) || other.host == host)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.channelId, channelId) || other.channelId == channelId));
+}
 
-  /// 検索結果の先頭offset個をスキップします。
-  @override
-  final int? offset;
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,query,sinceId,untilId,rangeStartAt,rangeEndAt,limit,offset,host,userId,channelId);
 
-  /// The local host is represented with `null`.
-  @override
-  final String? host;
+@override
+String toString() {
+  return 'NotesSearchRequest(query: $query, sinceId: $sinceId, untilId: $untilId, rangeStartAt: $rangeStartAt, rangeEndAt: $rangeEndAt, limit: $limit, offset: $offset, host: $host, userId: $userId, channelId: $channelId)';
+}
 
-  /// 指定すると、そのユーザが作成したノートを検索します。
-  @override
-  final String? userId;
 
-  /// 指定すると、そのチャンネルに属するノートを検索します。userIdと併せて指定した場合、channelIdは無視されます。
-  @override
-  final String? channelId;
-
-  /// Create a copy of NotesSearchRequest
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$NotesSearchRequestCopyWith<_NotesSearchRequest> get copyWith =>
-      __$NotesSearchRequestCopyWithImpl<_NotesSearchRequest>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$NotesSearchRequestToJson(
-      this,
-    );
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _NotesSearchRequest &&
-            (identical(other.query, query) || other.query == query) &&
-            (identical(other.sinceId, sinceId) || other.sinceId == sinceId) &&
-            (identical(other.untilId, untilId) || other.untilId == untilId) &&
-            (identical(other.limit, limit) || other.limit == limit) &&
-            (identical(other.offset, offset) || other.offset == offset) &&
-            (identical(other.host, host) || other.host == host) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.channelId, channelId) ||
-                other.channelId == channelId));
-  }
-
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, query, sinceId, untilId, limit,
-      offset, host, userId, channelId);
-
-  @override
-  String toString() {
-    return 'NotesSearchRequest(query: $query, sinceId: $sinceId, untilId: $untilId, limit: $limit, offset: $offset, host: $host, userId: $userId, channelId: $channelId)';
-  }
 }
 
 /// @nodoc
-abstract mixin class _$NotesSearchRequestCopyWith<$Res>
-    implements $NotesSearchRequestCopyWith<$Res> {
-  factory _$NotesSearchRequestCopyWith(
-          _NotesSearchRequest value, $Res Function(_NotesSearchRequest) _then) =
-      __$NotesSearchRequestCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String query,
-      String? sinceId,
-      String? untilId,
-      int? limit,
-      int? offset,
-      String? host,
-      String? userId,
-      String? channelId});
-}
+abstract mixin class _$NotesSearchRequestCopyWith<$Res> implements $NotesSearchRequestCopyWith<$Res> {
+  factory _$NotesSearchRequestCopyWith(_NotesSearchRequest value, $Res Function(_NotesSearchRequest) _then) = __$NotesSearchRequestCopyWithImpl;
+@override @useResult
+$Res call({
+ String query, String? sinceId, String? untilId,@EpocTimeDateTimeConverter.withMilliSeconds() DateTime? rangeStartAt,@EpocTimeDateTimeConverter.withMilliSeconds() DateTime? rangeEndAt, int? limit, int? offset, String? host, String? userId, String? channelId
+});
 
+
+
+
+}
 /// @nodoc
 class __$NotesSearchRequestCopyWithImpl<$Res>
     implements _$NotesSearchRequestCopyWith<$Res> {
@@ -269,55 +177,25 @@ class __$NotesSearchRequestCopyWithImpl<$Res>
   final _NotesSearchRequest _self;
   final $Res Function(_NotesSearchRequest) _then;
 
-  /// Create a copy of NotesSearchRequest
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? query = null,
-    Object? sinceId = freezed,
-    Object? untilId = freezed,
-    Object? limit = freezed,
-    Object? offset = freezed,
-    Object? host = freezed,
-    Object? userId = freezed,
-    Object? channelId = freezed,
-  }) {
-    return _then(_NotesSearchRequest(
-      query: null == query
-          ? _self.query
-          : query // ignore: cast_nullable_to_non_nullable
-              as String,
-      sinceId: freezed == sinceId
-          ? _self.sinceId
-          : sinceId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      untilId: freezed == untilId
-          ? _self.untilId
-          : untilId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      limit: freezed == limit
-          ? _self.limit
-          : limit // ignore: cast_nullable_to_non_nullable
-              as int?,
-      offset: freezed == offset
-          ? _self.offset
-          : offset // ignore: cast_nullable_to_non_nullable
-              as int?,
-      host: freezed == host
-          ? _self.host
-          : host // ignore: cast_nullable_to_non_nullable
-              as String?,
-      userId: freezed == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      channelId: freezed == channelId
-          ? _self.channelId
-          : channelId // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Create a copy of NotesSearchRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? query = null,Object? sinceId = freezed,Object? untilId = freezed,Object? rangeStartAt = freezed,Object? rangeEndAt = freezed,Object? limit = freezed,Object? offset = freezed,Object? host = freezed,Object? userId = freezed,Object? channelId = freezed,}) {
+  return _then(_NotesSearchRequest(
+query: null == query ? _self.query : query // ignore: cast_nullable_to_non_nullable
+as String,sinceId: freezed == sinceId ? _self.sinceId : sinceId // ignore: cast_nullable_to_non_nullable
+as String?,untilId: freezed == untilId ? _self.untilId : untilId // ignore: cast_nullable_to_non_nullable
+as String?,rangeStartAt: freezed == rangeStartAt ? _self.rangeStartAt : rangeStartAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,rangeEndAt: freezed == rangeEndAt ? _self.rangeEndAt : rangeEndAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,limit: freezed == limit ? _self.limit : limit // ignore: cast_nullable_to_non_nullable
+as int?,offset: freezed == offset ? _self.offset : offset // ignore: cast_nullable_to_non_nullable
+as int?,host: freezed == host ? _self.host : host // ignore: cast_nullable_to_non_nullable
+as String?,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String?,channelId: freezed == channelId ? _self.channelId : channelId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/lib/src/data/notes/notes_search_request.g.dart
+++ b/lib/src/data/notes/notes_search_request.g.dart
@@ -11,6 +11,14 @@ _NotesSearchRequest _$NotesSearchRequestFromJson(Map<String, dynamic> json) =>
       query: json['query'] as String,
       sinceId: json['sinceId'] as String?,
       untilId: json['untilId'] as String?,
+      rangeStartAt: _$JsonConverterFromJson<int, DateTime>(
+        json['rangeStartAt'],
+        const EpocTimeDateTimeConverter.withMilliSeconds().fromJson,
+      ),
+      rangeEndAt: _$JsonConverterFromJson<int, DateTime>(
+        json['rangeEndAt'],
+        const EpocTimeDateTimeConverter.withMilliSeconds().fromJson,
+      ),
       limit: (json['limit'] as num?)?.toInt(),
       offset: (json['offset'] as num?)?.toInt(),
       host: json['host'] as String?,
@@ -23,9 +31,27 @@ Map<String, dynamic> _$NotesSearchRequestToJson(_NotesSearchRequest instance) =>
       'query': instance.query,
       'sinceId': instance.sinceId,
       'untilId': instance.untilId,
+      'rangeStartAt': _$JsonConverterToJson<int, DateTime>(
+        instance.rangeStartAt,
+        const EpocTimeDateTimeConverter.withMilliSeconds().toJson,
+      ),
+      'rangeEndAt': _$JsonConverterToJson<int, DateTime>(
+        instance.rangeEndAt,
+        const EpocTimeDateTimeConverter.withMilliSeconds().toJson,
+      ),
       'limit': instance.limit,
       'offset': instance.offset,
       'host': instance.host,
       'userId': instance.userId,
       'channelId': instance.channelId,
     };
+
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) => json == null ? null : fromJson(json as Json);
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) => value == null ? null : toJson(value);

--- a/test/notes_search_request_test.dart
+++ b/test/notes_search_request_test.dart
@@ -1,0 +1,41 @@
+import 'package:misskey_dart/misskey_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test("rangeStartAt/rangeEndAtがエポックミリ秒で送られること", () {
+    final request = NotesSearchRequest(
+      query: "ねこ",
+      rangeStartAt: DateTime.utc(2026, 8, 3, 6, 30),
+      rangeEndAt: DateTime.utc(2026, 8, 3, 7, 30),
+    );
+
+    final json = request.toJson();
+    expect(
+      json["rangeStartAt"],
+      DateTime.utc(2026, 8, 3, 6, 30).millisecondsSinceEpoch,
+    );
+    expect(
+      json["rangeEndAt"],
+      DateTime.utc(2026, 8, 3, 7, 30).millisecondsSinceEpoch,
+    );
+  });
+
+  test("指定しなければnullのままであること", () {
+    final json = const NotesSearchRequest(query: "ねこ").toJson();
+
+    expect(json["rangeStartAt"], isNull);
+    expect(json["rangeEndAt"], isNull);
+  });
+
+  test("復元できること", () {
+    final request = NotesSearchRequest(
+      query: "ねこ",
+      rangeStartAt: DateTime.utc(2026, 8, 3, 6, 30),
+    );
+
+    final restored = NotesSearchRequest.fromJson(request.toJson());
+
+    expect(restored.rangeStartAt?.toUtc(), DateTime.utc(2026, 8, 3, 6, 30));
+    expect(restored.rangeEndAt, isNull);
+  });
+}


### PR DESCRIPTION
## なにをしたか

`notes/search` は投稿日時での絞り込みに `rangeStartAt` / `rangeEndAt` を
エポックミリ秒で受け取るが、`NotesSearchRequest` はどちらも持っていなかった。
`AntennasNotesRequest` の日時と同じく `EpocTimeDateTimeConverter.withMilliSeconds`
で通している。

miria の「ノートの検索で投稿日時を指定できるようにする」
([miria#294](https://github.com/shiosyakeyakini-info/miria/issues/294)) で必要になった。

## なぜ sinceDate / untilDate ではないか

同じエンドポイントには `sinceDate` / `untilDate` もあるが、あちらはサーバー側で
`idService.gen()` を通して `sinceId` / `untilId` に変換される。つまりページングの
カーソルなので、`untilId` で続きを読む使い方とは併用できない。

```ts
// packages/backend/src/server/api/endpoints/notes/search.ts
const untilId = ps.untilId ?? (ps.untilDate ? this.idService.gen(ps.untilDate!) : undefined);
const sinceId = ps.sinceId ?? (ps.sinceDate ? this.idService.gen(ps.sinceDate!) : undefined);
```

`rangeStartAt` / `rangeEndAt` のほうは `searchService.searchNote` に絞り込み条件と
して渡るので、ページングと独立している。Misskey Web の検索画面
(`search.note.vue`) も日時の指定にはこちらを使っている。

## 確認したこと

ローカルの Misskey 2026.7.0 で確認した。

- 投稿日時が1時間半に収まる37件を、境目の日時で分けると 19件 / 18件になる
- `rangeEndAt` と `untilId` を併用しても、2ページ目に重複が出ず、範囲外のノートも
  混ざらない
- `test/notes_search_request_test.dart` で、エポックミリ秒で載ること・未指定なら
  null のままであること・復元できることを検証

## 生成物について

`notes_search_request.freezed.dart` だけ再生成している。手元の freezed
(3.2.3 / 3.0.6 いずれも) は `// dart format off` 区間を整形せずに吐くため、
全体を再生成するとこのファイル以外も差分だらけになってしまう。
コミット済みの生成物と同じ体裁で取り直したい場合はお任せする。